### PR TITLE
Constrain types

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,12 @@ Changelog
 1.1.3 - unreleased
 ------------------
 
+* Overrride allowedContentTypes and invokeFactory from PortalFolder
+  to mimic the behavior of Archetypes based folders. This allows the
+  registration of IConstrainTypes adapters to actually have the
+  expected effect.
+  [gaudenzius]
+
 1.1.2 - 2012-02-20
 ------------------
 

--- a/plone/dexterity/content.py
+++ b/plone/dexterity/content.py
@@ -33,6 +33,7 @@ import Products.CMFCore.permissions
 from Products.CMFCore.PortalContent import PortalContent
 from Products.CMFCore.PortalFolder import PortalFolderBase
 from Products.CMFCore.CMFCatalogAware import CMFCatalogAware
+from Products.CMFPlone.interfaces import IConstrainTypes
 
 from Products.CMFDefault.DublinCore import DefaultDublinCoreImpl
 from Products.CMFDefault.utils import tuplize
@@ -359,6 +360,30 @@ class Container(DAVCollectionMixin, BrowserDefaultMixin, CMFCatalogAware, CMFOrd
                 raise Unauthorized, (
                     "Do not have permissions to remove this object")
         return super(Container, self).manage_delObjects(ids, REQUEST=REQUEST)
+
+    # override PortalFolder's allowedContentTypes to respect IConstrainTypes
+    # adapters
+    def allowedContentTypes(self, context=None):
+        if not context:
+            context = self
+
+        constrains = IConstrainTypes(context, None)
+        if not constrains:
+            return super(Container, self).allowedContentTypes()
+
+        return constrains.allowedContentTypes()
+
+    # override PortalFolder's invokeFactory to respect IConstrainTypes
+    # adapters
+    def invokeFactory(self, type_name, id, RESPONSE=None, *args, **kw):
+        """Invokes the portal_types tool
+        """
+        constrains = IConstrainTypes(self, None)
+
+        if constrains and not type_name in [fti.getId() for fti in constrains.allowedContentTypes()]:
+            raise ValueError('Subobject type disallowed by IConstrainTypes adapter: %s' % type_name)
+
+        return super(Container, self).invokeFactory(type_name, id, RESPONSE, *args, **kw)
 
 
 def reindexOnModify(content, event):

--- a/plone/dexterity/tests/test_content.py
+++ b/plone/dexterity/tests/test_content.py
@@ -3,11 +3,13 @@ import unittest
 from plone.mocktestcase import MockTestCase
 
 from zope.interface import Interface, alsoProvides
-from zope.component import provideAdapter
+from zope.component import provideAdapter, getUtility
 
 import zope.schema
 
-from plone.dexterity.interfaces import IDexterityFTI
+from Products.CMFPlone.interfaces import IConstrainTypes
+
+from plone.dexterity.interfaces import IDexterityFTI, IDexterityContainer
 
 from plone.dexterity.fti import DexterityFTI
 from plone.dexterity.schema import SCHEMA_CACHE
@@ -674,6 +676,31 @@ class TestContent(MockTestCase):
         item.manage_permission(DeleteObjects, ('Anonymous',))
         container.manage_delObjects(['test'])
         self.assertFalse('test' in container)
+
+    def test_iconstraintypes_adapter(self):
+
+        class DummyConstrainTypes(object):
+
+            def __init__(self, context):
+                self.context = context
+
+            def allowedContentTypes(self):
+                fti = getUtility(IDexterityFTI, name=u"testtype")
+                return [fti]
+
+        self.mock_adapter(DummyConstrainTypes, IConstrainTypes, (IDexterityContainer, ))
+
+        # FTI mock
+        fti_mock = self.mocker.proxy(DexterityFTI(u"testtype"))
+        self.expect(fti_mock.getId()).result(u"testtype")
+        self.mock_utility(fti_mock, IDexterityFTI, name=u"testtype")
+
+        self.replay()
+
+        folder = Container(id="testfolder")
+
+        self.assertEquals(folder.allowedContentTypes(), [fti_mock])
+        self.assertRaises(ValueError, folder.invokeFactory, u"disallowed_type", id="test")
 
 
 def test_suite():


### PR DESCRIPTION
Overrride allowedContentTypes and invokeFactory from PortalFolder
to mimic the behavior of Archetypes based folders. This allows the
registration of IConstrainTypes adapters to actually have the
expected effect.
