### PR TITLE
utils.createContent better behavior support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 2.2.2 (unreleased)
 ------------------
 
+- Let utils.createContent also handle setting of attributes on behaviors, which
+  derive from other behaviors.
+  [thet]
+
 - Add a 'success' class to the status message shown after successfully
   adding or editing an item.  The previous 'info' class is also
   retained for backwards-compatibility.
@@ -23,7 +27,8 @@ Changelog
 2.2.0 (2014-01-31)
 ------------------
 
-- utils.createContent honors behaviors [toutpt]
+- utils.createContent honors behaviors.
+  [toutpt]
 
 - Date index method works even if source field is a dexterity field
   wich provides a  datetime python value.

--- a/plone/dexterity/utils.py
+++ b/plone/dexterity/utils.py
@@ -140,12 +140,12 @@ def createContent(portal_type, **kw):
 
     for schema in schemas:
         behavior = schema(content)
-        for name in schema.names():
-            if name in fields:
-                setattr(behavior, name, fields[name])
+        for name, value in fields.items():
+            if hasattr(behavior, name):
+                setattr(behavior, name, value)
                 del fields[name]
 
-    for (key,value) in fields.items():
+    for (key, value) in fields.items():
         setattr(content, key, value)
 
     notify(ObjectCreatedEvent(content))


### PR DESCRIPTION
Let utils.createContent also handle setting of attributes on behaviors, which derive from other behaviors.\

this pull-request extends @toutpt change of behavior support for createContent to also support derived behaviors, which are made of several ones.
e.g. plone.app.dexterity.behaviors.metadata.IDublinCore is made up of IBasic, ICategorization, etc. But `schema.names()` in https://github.com/plone/plone.dexterity/blob/master/plone/dexterity/utils.py#L143 returns an empty list.
This change iterates over fieldnames and sets it on the behavior, if the behavior has an attribute with this name.
this now correctly utilizes the ICategorization behavior, when someone uses createContent with a `subjects` keyword, where the behavior sets it `context.subject`. Related is: https://github.com/plone/plone.app.dexterity/issues/118

I don't have a test for this yet. Let's discuss first, if this change makes sense.
