### PR TITLE
fix: overhaul - lookup of behaviors at several places unified and sane usage of interface (schema) and marker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,18 +4,18 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
-- Big major overhaul to use always the same way everywhere how to fetch
-  main-schema, behavior-schemas and its markers. This was very scrmabled:
-  Sometime never took into account stuff from behaviors, or only from FTI
-  based behaviors and not from IBehaviorAssignable adapter. Also the caching
-  was cleaned up. The tests are now better readable (at least i hope so).
-  In order to avoid circular imports some methods where moved fro ``utils.py``
-  to ``schema.py``. Deprecations are in place.
+- Big major overhaul to use everywhere the same way to fetch the main schema,
+  behavior schemata and its markers. This was very scrmabled: sometimes
+  behaviors weren't taken into account, or only FTI based behaviors but not
+  those returned by the IBehaviorAssignable adapter. Also the caching was
+  cleaned up. The tests are now better readable (at least I hope so).  In order
+  to avoid circular imports some methods where moved fro ``utils.py`` to
+  ``schema.py``.  Deprecations are in place.
   [jensens]
 
-- Fix (security): Attribute access to schema fields can be protected. This worked
-  for direct schemas, but was not implemented for permissions coming from
-  behaviors.
+- Fix (security): Attribute access to schema fields can be protected. This
+  worked for direct schemas, but was not implemented for permissions coming
+  from behaviors.
   [jensens]
 
 2.2.4 (2014-10-20)

--- a/plone/dexterity/CONVENTIONS.txt
+++ b/plone/dexterity/CONVENTIONS.txt
@@ -1,6 +1,7 @@
 Dexterity coding conventions
 ============================
 
-Follow the `plone.api code conventions <http://docs.plone.org/external/plone.api/docs/contribute/conventions.html>_
+Follow the `plone.api code conventions
+<http://docs.plone.org/external/plone.api/docs/contribute/conventions.html>_
 
 Dont use grok.

--- a/plone/dexterity/browser/traversal.py
+++ b/plone/dexterity/browser/traversal.py
@@ -41,7 +41,7 @@ class DexterityPublishTraverse(DefaultPublishTraverse):
            and name == DAV_FOLDER_DATA_ID:
             return FolderDataResource(
                 DAV_FOLDER_DATA_ID, context
-                ).__of__(context)
+            ).__of__(context)
 
         defaultTraversal = super(
             DexterityPublishTraverse,

--- a/plone/dexterity/content.py
+++ b/plone/dexterity/content.py
@@ -73,7 +73,8 @@ def _default_from_schema(context, schema, fieldname):
 
 class FTIAwareSpecification(ObjectSpecificationDescriptor):
     """A __providedBy__ decorator that returns the interfaces provided by
-    the object, plus the schema interface set in the FTI.    """
+    the object, plus the schema interface set in the FTI.
+    """
 
     def __get__(self, inst, cls=None):
         # We're looking at a class - fall back on default
@@ -374,7 +375,7 @@ class DexterityContent(DAVResourceMixin, PortalContent, PropertyManager,
             creator = user and user.getId()
 
         # call self.listCreators() to make sure self.creators exists
-        if creator and not creator in self.listCreators():
+        if creator and creator not in self.listCreators():
             self.creators = self.creators + (creator, )
 
     @security.protected(permissions.ModifyPortalContent)
@@ -631,7 +632,7 @@ class Item(PasteBehaviourMixin, BrowserDefaultMixin, DexterityContent):
     manage_options = PropertyManager.manage_options + ({
         'label': 'View',
         'action': 'view',
-        },) + CMFCatalogAware.manage_options + SimpleItem.manage_options
+    },) + CMFCatalogAware.manage_options + SimpleItem.manage_options
 
     # Be explicit about which __getattr__ to use
     __getattr__ = DexterityContent.__getattr__

--- a/plone/dexterity/exportimport.py
+++ b/plone/dexterity/exportimport.py
@@ -67,7 +67,7 @@ class DexterityContentExporterImporter(FolderishExporterImporter):
             text=stream.getvalue(),
             content_type='text/comma-separated-values',
             subdir=subdir,
-            )
+        )
 
         props = context.manage_FTPget()
         if hasattr(props, 'read'):
@@ -77,7 +77,7 @@ class DexterityContentExporterImporter(FolderishExporterImporter):
             text=props,
             content_type='text/plain',
             subdir=subdir,
-            )
+        )
 
         for object_id, object, adapter in exportable:
             if adapter is not None:

--- a/plone/dexterity/fti.py
+++ b/plone/dexterity/fti.py
@@ -332,7 +332,7 @@ class DexterityFTI(base.DynamicViewTypeInformation):
         if colons == 1 and self.model_file[1:3] != ':\\':
             package, filename = self.model_file.split(':')
             mod = utils.resolveDottedName(package)
-             # let / work as path separator on all platforms
+            # let / work as path separator on all platforms
             filename = filename.replace('/', os.path.sep)
             model_file = os.path.join(os.path.split(mod.__file__)[0], filename)
         else:

--- a/plone/dexterity/tests/test_behavior.py
+++ b/plone/dexterity/tests/test_behavior.py
@@ -82,5 +82,6 @@ class TestBehavior(MockTestCase):
             list(assignable.enumerateBehaviors())
         )
 
+
 def test_suite():
     return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/plone/dexterity/tests/test_content.py
+++ b/plone/dexterity/tests/test_content.py
@@ -797,7 +797,7 @@ class TestContent(MockTestCase):
         self.assertEqual(c.foo, "bar")
 
     def test_setTitle_converts_to_unicode(self):
-        #fix http://code.google.com/p/dexterity/issues/detail?id=145
+        # fix http://code.google.com/p/dexterity/issues/detail?id=145
         i = Item()
         i.setTitle("é")
         self.assertEqual(i.title, u"é")

--- a/plone/dexterity/tests/test_exportimport.py
+++ b/plone/dexterity/tests/test_exportimport.py
@@ -23,7 +23,7 @@ class ExportImportTests(unittest.TestCase):
         self.assertEqual(
             export_context._wrote[-1],
             ('.data', 'title: Foo', 'text/plain')
-            )
+        )
 
     def test_import(self):
         # Make sure our importer delegates to PUT()

--- a/plone/dexterity/tests/test_fti.py
+++ b/plone/dexterity/tests/test_fti.py
@@ -630,7 +630,7 @@ class TestFTIEvents(MockTestCase):
         self.assertEqual(None, queryUtility(IDexterityFTI, name=portal_type))
         self.assertEqual(None, queryUtility(IFactory, name=portal_type))
 
-    def test_components_unregistered_on_delete_does_not_error_with_no_components(self):
+    def test_components_unregistered_on_delete_does_not_error_with_no_components(self):  # noqa
         portal_type = u"testtype"
         fti = DexterityFTI(portal_type)
         container_dummy = self.create_dummy()

--- a/plone/dexterity/tests/test_schema.py
+++ b/plone/dexterity/tests/test_schema.py
@@ -200,5 +200,6 @@ class TestSchemaModuleFactory(MockTestCase):
             schema.splitSchemaName('prefix_0_type_1_one_2_two')
         )
 
+
 def test_suite():
     return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/plone/dexterity/tests/test_security.py
+++ b/plone/dexterity/tests/test_security.py
@@ -290,7 +290,7 @@ class TestAttributeProtection(MockTestCase):
             container.__allow_access_to_unprotected_subobjects__(
                 'test',
                 u"foo"
-                )
+            )
         )
 
         # # run 2: schema and no behavior access to known non schema attribute
@@ -299,7 +299,7 @@ class TestAttributeProtection(MockTestCase):
             container.__allow_access_to_unprotected_subobjects__(
                 'foo',
                 u"bar"
-                )
+            )
         )
 
         # # run 3: schema and no behavior, unknown attributes are allowed
@@ -308,7 +308,7 @@ class TestAttributeProtection(MockTestCase):
             container.__allow_access_to_unprotected_subobjects__(
                 'random',
                 u"stuff"
-                )
+            )
         )
 
         # # run 4: schema and behavior
@@ -317,7 +317,7 @@ class TestAttributeProtection(MockTestCase):
             container.__allow_access_to_unprotected_subobjects__(
                 'test2',
                 u"foo2"
-                )
+            )
         )
 
         # run 5: no schema but behavior
@@ -326,7 +326,7 @@ class TestAttributeProtection(MockTestCase):
             container.__allow_access_to_unprotected_subobjects__(
                 'test2',
                 u"foo2"
-                )
+            )
         )
 
     def test_no_tagged_value(self):

--- a/plone/dexterity/tests/test_utils.py
+++ b/plone/dexterity/tests/test_utils.py
@@ -123,6 +123,5 @@ class TestUtils(MockTestCase):
         )
 
 
-
 def test_suite():
     return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/plone/dexterity/tests/test_webdav.py
+++ b/plone/dexterity/tests/test_webdav.py
@@ -869,7 +869,7 @@ class TestFileRepresentation(MockTestCase):
         self.expect(
             getToolByName_mock(
                 container, 'content_type_registry', None
-                )
+            )
         ).result(None)
 
         factory = DefaultFileFactory(container)

--- a/setup.py
+++ b/setup.py
@@ -74,4 +74,4 @@ setup(
     entry_points="""
     # -*- Entry points: -*-
     """,
-    )
+)


### PR DESCRIPTION
Fix (security): Attribute access to schema fields can be protected. This worked for direct schemas, but was not implemented for permissions coming from behaviors.
