### PR TITLE
Fix to pass resource name from webdav PUT to createObject

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 2.3.1 (unreleased)
 ------------------
 
+- Fix issue where webdav PUT created items with empty id
+  [datakurre]
 - fix #27: createContent ignores empty fields
   [jensens]
 

--- a/plone/dexterity/filerepresentation.py
+++ b/plone/dexterity/filerepresentation.py
@@ -481,7 +481,7 @@ class DefaultFileFactory(object):
                     typeObjectName
                 )
 
-            obj = createObject(targetType.factory)
+            obj = createObject(targetType.factory, name)
 
             if hasattr(obj, '_setPortalTypeName'):
                 obj._setPortalTypeName(targetType.getId())

--- a/plone/dexterity/tests/test_webdav.py
+++ b/plone/dexterity/tests/test_webdav.py
@@ -1098,6 +1098,66 @@ class TestFileRepresentation(MockTestCase):
             factory('test.html', 'text/html', '<html />')
         )
 
+    def test_file_factory_content_type_factory_utility(self):
+        container_mock = self.mocker.mock()
+        child_fti_mock = self.mocker.mock()
+        container_fti_mock = self.mocker.mock()
+        ctr_mock = self.mocker.mock()
+        pt_mock = self.mocker.mock()
+
+        getToolByName_mock = self.mocker.replace(
+            'Products.CMFCore.utils.getToolByName'
+        )
+
+        self.expect(
+            getToolByName_mock(
+                container_mock, 'content_type_registry', None
+            )
+        ).result(ctr_mock)
+
+        self.expect(
+            getToolByName_mock(
+                container_mock, 'portal_types')).result(pt_mock)
+
+        self.expect(
+            ctr_mock.findTypeName('test.html', 'text/html', '<html />')
+        ).result('childtype')
+
+        self.expect(
+            pt_mock.getTypeInfo('childtype')
+        ).result(child_fti_mock)
+
+        self.expect(
+            pt_mock.getTypeInfo(container_mock)
+        ).result(container_fti_mock)
+
+        self.expect(
+            container_fti_mock.allowType('childtype')
+        ).result(True)
+
+        self.expect(
+            child_fti_mock.isConstructionAllowed(container_mock)
+        ).result(True)
+
+        self.expect(
+            child_fti_mock.getId()
+        ).result('childtype')
+
+        self.expect(child_fti_mock.product).result(None)
+        self.expect(child_fti_mock.factory).result('childtype-factory')
+
+        def factory(*args, **kwargs):
+            return Item(*args, **kwargs)
+        self.mock_utility(factory, IFactory, name=u'childtype-factory')
+
+        factory = DefaultFileFactory(container_mock)
+
+        self.replay()
+
+        item = factory('test.html', 'text/html', '<html />')
+
+        self.assertEqual('test.html', item.id)
+
     def test_readfile_mimetype_no_message_no_fields(self):
 
         class ITest(Interface):


### PR DESCRIPTION
This should fix issue, where WebDAV PUT created (Dexterity) item objects without id