### PR TITLE
fix Container default description to be unicode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 2.3.2 (unreleased)
 ------------------
 
+- fix Container default description to be unicode too.
+  [jone]
+
 - check allowed types for add form
   [vangheem]
 
@@ -479,4 +482,3 @@ Changelog
 ------------------
 
 * Initial release
-

--- a/plone/dexterity/content.py
+++ b/plone/dexterity/content.py
@@ -661,6 +661,7 @@ class Container(
         permissions.ModifyPortalContent, 'manage_renameObjects')
 
     isPrincipiaFolderish = 1
+    description = u''
 
     # make sure CMFCatalogAware's manage_options don't take precedence
     manage_options = PortalFolderBase.manage_options


### PR DESCRIPTION
:construction: Will be fixed by #35 

The DexterityContent and Item default description is an empty unicode, but the Container was an empty string because of the MRO.

This changes the default description of containers to be unicode as well in order to be valid with the z3cform / field constraints.

Before:
```python
>>> from plone.dexterity import content
>>> content.DexterityContent.description
u''
>>> content.Item.description
u''
>>> content.Container.description
''
```