### PR TITLE
Remove bobobase_modification_time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog
 2.3.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- No longer rely on deprecated ``bobobase_modification_time`` from
+  ``Persistence.Persistent``.
+  [thet]
 
 
 2.3.5 (2015-09-20)

--- a/plone/dexterity/content.py
+++ b/plone/dexterity/content.py
@@ -545,7 +545,7 @@ class DexterityContent(DAVResourceMixin, PortalContent, PropertyManager,
         date = self.modification_date
         if date is None:
             # Upgrade.
-            date = self.bobobase_modification_time()
+            date = DateTime(self._p_mtime)
             self.modification_date = date
         date = datify(date)
         return date


### PR DESCRIPTION
No longer rely on deprecated bobobase_modification_time from Persistence.Persistent.

see changelog for Zope 4.0a1: https://github.com/zopefoundation/Zope/blob/master/CHANGES.rst