### PR TITLE
make utils/datify work with newer DateTime and pytz. Adjust tests to …

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,14 +2,19 @@ Changelog
 =========
 
 
-2.3.8 (unreleased)
+2.4.0 (unreleased)
 ------------------
 
 New:
 
-- *add item here*
+- Update to/ depend on pytz 2015.7 and DateTime 4.0.1
+  [jensens]
 
 Fixes:
+
+- make utils/datify work with newer DateTime and pytz. Adjust tests to reflect
+  changes.
+  [jensens]
 
 - Fix: duplicate aq_base w/o using Aqcuistion API resulted in an AttributeError
   that was masqued in the calling hasattr and resulted in wrong conclusion.

--- a/plone/dexterity/tests/test_content.py
+++ b/plone/dexterity/tests/test_content.py
@@ -675,11 +675,16 @@ class TestContent(MockTestCase):
         self.assertEqual(i.rights, 'CC')
         self.assertEqual(i.Rights(), 'CC')
         self.assertEqual(i.creation_date, i.created())
-        self.assertEqual(i.CreationDate(zone=summer_timezone)[:19], i.creation_date.ISO()[:19])
+        self.assertEqual(
+            i.CreationDate(zone=summer_timezone)[:19],
+            i.creation_date.ISO()[:19]
+        )
         self.assertEqual(i.modification_date, i.creation_date)
         self.assertEqual(i.modification_date, i.modified())
         self.assertEqual(
-            i.ModificationDate(zone=summer_timezone)[:19], i.modification_date.ISO()[:19])
+            i.ModificationDate(zone=summer_timezone)[:19],
+            i.modification_date.ISO()[:19]
+        )
         self.assertEqual(i.Date(), i.EffectiveDate())
         self.assertEqual(i.Identifier(), i.absolute_url())
 
@@ -717,11 +722,16 @@ class TestContent(MockTestCase):
             i.ExpirationDate(zone=summer_timezone)[:10], '2013-07-09')
         self.assertEqual(i.expires(), DateTime('07/09/2013'))
         self.assertEqual(i.creation_date, i.created())
-        self.assertEqual(i.CreationDate(zone=summer_timezone)[:19], i.creation_date.ISO()[:19])
+        self.assertEqual(
+            i.CreationDate(zone=summer_timezone)[:19],
+            i.creation_date.ISO()[:19]
+        )
         self.assertEqual(i.modification_date, i.creation_date)
         self.assertEqual(i.modification_date, i.modified())
         self.assertEqual(
-            i.ModificationDate(zone=summer_timezone)[:19], i.modification_date.ISO()[:19])
+            i.ModificationDate(zone=summer_timezone)[:19],
+            i.modification_date.ISO()[:19]
+        )
         self.assertEqual(i.Date(), i.EffectiveDate())
 
     def test_item_dublincore_datetime(self):
@@ -735,7 +745,6 @@ class TestContent(MockTestCase):
         mocked_datetime = datetime_patcher.start()
         mocked_datetime.return_value = DateTime(2014, 6, 1)
         self.addCleanup(datetime_patcher.stop)
-
         i = Item(
             title=u"Emperor Penguin",
             description=u'One of the most magnificent birds.',
@@ -752,26 +761,48 @@ class TestContent(MockTestCase):
 
         summer_timezone = DateTime('2010/08/20').timezone()
         self.assertEqual(
-            i.effective_date, DateTime('08/20/2010 12:59:59 GMT-5'))
+            i.effective_date,
+            DateTime('2010/08/20 12:59:59 US/Eastern')
+        )
         self.assertEqual(
             i.EffectiveDate(zone=summer_timezone),
-            DateTime('2010-08-20 12:59:59 GMT-5').toZone(summer_timezone).ISO()
+            DateTime(
+                '2010/08/20 12:59:59 US/Eastern'
+            ).toZone(
+                summer_timezone
+            ).ISO()
         )
-        self.assertEqual(i.effective(), DateTime('08/20/2010 12:59:59 GMT-5'))
+        self.assertEqual(
+            i.effective(),
+            DateTime('2010/08/20 12:59:59 US/Eastern')
+        )
         self.assertEqual(
             i.expiration_date,
-            DateTime('07/09/2013 12:59:59 GMT-5')
+            DateTime('07/09/2013 12:59:59 US/Eastern')
         )
         self.assertEqual(
             i.ExpirationDate(zone=summer_timezone),
-            DateTime('2013-07-09 12:59:59 GMT-5').toZone(summer_timezone).ISO()
+            DateTime(
+                '2013-07-09 12:59:59 US/Eastern'
+            ).toZone(
+                summer_timezone
+            ).ISO()
         )
-        self.assertEqual(i.expires(), DateTime('2013/07/09 12:59:59 GMT-5'))
+        self.assertEqual(
+            i.expires(),
+            DateTime('2013/07/09 12:59:59 US/Eastern')
+        )
         self.assertEqual(i.creation_date, i.created())
-        self.assertEqual(i.CreationDate(zone=summer_timezone), i.creation_date.ISO())
+        self.assertEqual(
+            i.CreationDate(zone=summer_timezone),
+            i.creation_date.ISO()
+        )
         self.assertEqual(i.modification_date, i.creation_date)
         self.assertEqual(i.modification_date, i.modified())
-        self.assertEqual(i.ModificationDate(zone=summer_timezone), i.modification_date.ISO())
+        self.assertEqual(
+            i.ModificationDate(zone=summer_timezone),
+            i.modification_date.ISO()
+        )
         self.assertEqual(i.Date(), i.EffectiveDate())
 
     def test_item_notifyModified(self):

--- a/plone/dexterity/utils.py
+++ b/plone/dexterity/utils.py
@@ -197,33 +197,33 @@ def createContentInContainer(container, portal_type, checkConstraints=True,
     )
 
 
-def safe_utf8(s):
-    if isinstance(s, unicode):
-        s = s.encode('utf8')
-    return s
+def safe_utf8(st):
+    if isinstance(st, unicode):
+        st = st.encode('utf8')
+    return st
 
 
-def safe_unicode(s):
-    if isinstance(s, str):
-        s = s.decode('utf8')
-    return s
+def safe_unicode(st):
+    if isinstance(st, str):
+        st = st.decode('utf8')
+    return st
 
 
-def datify(s):
+def datify(in_date):
     """Get a DateTime object from a string (or anything parsable by DateTime,
        a datetime.date, a datetime.datetime
     """
-    if not isinstance(s, DateTime):
-        if s == 'None':
-            s = None
-        elif isinstance(s, datetime.datetime):
-            s = DateTime(s.isoformat())
-        elif isinstance(s, datetime.date):
-            s = DateTime(s.year, s.month, s.day)
-        elif s is not None:
-            s = DateTime(s)
-
-    return s
+    if isinstance(in_date, DateTime):
+        return in_date
+    if in_date == 'None':
+        in_date = None
+    elif isinstance(in_date, datetime.datetime):
+        in_date = DateTime(in_date)
+    elif isinstance(in_date, datetime.date):
+        in_date = DateTime(in_date.year, in_date.month, in_date.day)
+    elif in_date is not None:
+        in_date = DateTime(in_date)
+    return in_date
 
 
 def all_merged_tagged_values_dict(ifaces, key):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 
-version = '2.3.8.dev0'
+version = '2.4.0.dev0'
 
 short_description = """\
 Framework for content types as filesystem code and TTW (Zope/CMF/Plone)\
@@ -37,11 +37,7 @@ setup(
     install_requires=[
         # 'Acquisition',
         # 'AccessControl',
-        'Products.CMFCore',
-        'Products.CMFDynamicViewFTI',
-        'Products.statusmessages',
-        'ZODB3',
-        'Zope2',
+        'DateTime>=4.0.1',
         'plone.alterego',
         'plone.autoform>=1.0b2',
         'plone.behavior>=1.0b5',
@@ -52,7 +48,11 @@ setup(
         'plone.synchronize',
         'plone.uuid',
         'plone.z3cform>=0.6.0',
+        'Products.CMFCore',
+        'Products.CMFDynamicViewFTI',
+        'Products.statusmessages',
         'setuptools',
+        'ZODB3',
         'zope.annotation',
         'zope.browser',
         'zope.component',
@@ -66,6 +66,7 @@ setup(
         'zope.schema',
         'zope.security',
         'zope.size',
+        'Zope2',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
…reflect changes. Update to/ depend on pytz 2015.7 and DateTime 4.0.1

for reference see plone/buildout.coredev#160