### PR TITLE
addCreator should not add if a creator is already set for content

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,12 @@ Changelog
 2.4.1 (unreleased)
 ------------------
 
+Incompatibilities:
+
+- addCreator should not add if a creator is already set for content. This prevents every
+  editor on content from adding to the list of creators for an object.
+  [vangheem]
+
 New:
 
 - *add item here*

--- a/plone/dexterity/content.py
+++ b/plone/dexterity/content.py
@@ -370,6 +370,10 @@ class DexterityContent(DAVResourceMixin, PortalContent, PropertyManager,
     def addCreator(self, creator=None):
         """ Add creator to Dublin Core creators.
         """
+        if len(self.creators) > 0:
+            # do not add creator if one is already set
+            return
+
         if creator is None:
             user = getSecurityManager().getUser()
             creator = user and user.getId()


### PR DESCRIPTION
With the Ownership behavior calling addCreator on every instantiation, addCreator would add any editor to the list of creators for an object. This behavior has been happening for a long time as far as I can tell.

See: https://github.com/plone/plone.app.dexterity/blob/master/plone/app/dexterity/behaviors/metadata.py#L427