### PR TITLE
Set copy flags when copying container.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix error when copying DX containers with AT children which caused the
+  children to not have the UID updated properly.  [jone]
 
 
 2.2.7 (2016-05-05)

--- a/plone/dexterity/content.py
+++ b/plone/dexterity/content.py
@@ -221,6 +221,22 @@ class PasteBehaviourMixin(object):
                         'You can not add the copied content here.'
                     )
 
+    def _getCopy(self, container):
+        # Copy the _v_is_cp and _v_cp_refs flags from the original
+        # object (self) to the new copy.
+        # This has impact on how children will be handled.
+        # When the flags are missing, an Archetypes child object will not have
+        # the UID updated in some situations.
+        # Copied from Products.Archetypes.Referenceable.Referenceable._getCopy
+        is_cp_flag = getattr(self, '_v_is_cp', None)
+        cp_refs_flag = getattr(self, '_v_cp_refs', None)
+        ob = super(PasteBehaviourMixin, self)._getCopy(container)
+        if is_cp_flag:
+            setattr(ob, '_v_is_cp', is_cp_flag)
+        if cp_refs_flag:
+            setattr(ob, '_v_cp_refs', cp_refs_flag)
+        return ob
+
 
 @implementer(
     IDexterityContent,


### PR DESCRIPTION
⚠️ Target: `2.2.x` (Plone 4), see #61 for Plone 5

**Issue:**
When copying a DX container which has AT children, the UID of the AT children was not updated.
The reason for the error is that the DX container copy did not have the _v_is_cp flag while the AT children were processed and thus the flag was not properly delegated.

**Solution:**
By copying the _v_is_cp and _v_cp_refs flags to the copy we have the same behavior as it used to be with AT, which does fix the error.
Closes https://github.com/plone/Products.CMFPlone/issues/1735

**Tests:**
I could not reproduce the error in a test and therefore could not write a meaningful test. I'd appreciate inputs on how I can do that.
Though I have manually verified that this fix results in no longer having a broken UID index (see https://github.com/plone/Products.CMFPlone/issues/1735 for details).
