### PR TITLE
Remove newlines in Description accessor

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,12 +2,14 @@ Changelog
 =========
 
 
-2.4.6 (unreleased)
+2.5.0 (unreleased)
 ------------------
 
 Breaking changes:
 
-- *add item here*
+- When calling the DC metadata accessor for ``Description``, remove newlines from the output.
+  This makes the removal of newlines from the description behavior setter in plone.app.dexterity obsolete.
+  [thet]
 
 New features:
 

--- a/plone/dexterity/content.py
+++ b/plone/dexterity/content.py
@@ -416,10 +416,19 @@ class DexterityContent(DAVResourceMixin, PortalContent, PropertyManager,
 
     @security.protected(permissions.View)
     def Description(self):
+        value = self.description or ''
+
+        # If description is containing linefeeds the HTML
+        # validation can break.
+        # See http://bo.geekworld.dk/diazo-bug-on-html5-validation-errors/
+        # Remember: \r\n - Windows, \r - OS X, \n - Linux/Unix
+        value = value.replace('\r\n', ' ').replace('\r', ' ').replace('\n', ' ')  # noqa
+
         # this is a CMF accessor, so should return utf8-encoded
-        if isinstance(self.description, unicode):
-            return self.description.encode('utf-8')
-        return self.description or ''
+        if isinstance(value, unicode):
+            value = value.encode('utf-8')
+
+        return value
 
     @security.protected(permissions.View)
     def Type(self):

--- a/plone/dexterity/tests/test_content.py
+++ b/plone/dexterity/tests/test_content.py
@@ -905,6 +905,11 @@ class TestContent(MockTestCase):
         c = Container(description=None)
         self.assertEqual('', c.Description())
 
+    def test_Description_removes_newlines(self):
+        i = Item()
+        i.description = u'foo\r\nbar\nbaz\r'
+        self.assertEqual('foo bar baz ', i.Description())
+
     def test_Subject_converts_to_utf8(self):
         i = Item()
         i.subject = (u"é",)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 
-version = '2.4.6.dev0'
+version = '2.5.0.dev0'
 
 short_description = """\
 Framework for content types as filesystem code and TTW (Zope/CMF/Plone)\


### PR DESCRIPTION
When calling the DC metadata accessor for ``Description``, remove newlines from the output.
This makes the removal of newlines from the description behavior setter in plone.app.dexterity obsolete.