### PR TITLE
make sure default values get stored by add form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,11 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Make sure that all fields are initialized to their default value
+  when items are added via the add form. This is important in the case
+  of fields with a defaultFactory that can change with time
+  (such as defaulting to the current date).
+  [davisagli]
 
 
 2.5.0 (2017-02-12)

--- a/plone/dexterity/browser/add.py
+++ b/plone/dexterity/browser/add.py
@@ -14,8 +14,12 @@ from plone.z3cform import layout
 from plone.z3cform.interfaces import IDeferSecurityCheck
 from z3c.form import button
 from z3c.form import form
+from z3c.form.interfaces import IDataManager
+from z3c.form.interfaces import NOT_CHANGED
+from z3c.form.util import changedField
 from zope.component import createObject
 from zope.component import getUtility
+from zope.component import getMultiAdapter
 from zope.event import notify
 from zope.publisher.browser import BrowserPage
 
@@ -67,9 +71,9 @@ class DefaultAddForm(DexterityExtensibleForm, form.AddForm):
         if IAcquirer.providedBy(content):
             content = content.__of__(container)
 
-        form.applyChanges(self, content, data)
+        _applyChanges(self, content, data, force=True)
         for group in self.groups:
-            form.applyChanges(group, content, data)
+            _applyChanges(group, content, data, force=True)
 
         return aq_base(content)
 
@@ -167,3 +171,26 @@ class DefaultAddView(layout.FormWrapper, BrowserPage):
         if self.form_instance is not None \
            and not getattr(self.form_instance, 'portal_type', None):
             self.form_instance.portal_type = ti.getId()
+
+
+def _applyChanges(form, content, data, force=False):
+    # This is copied from z3c.form, but modified to add
+    # an option to always set values even if already set.
+    changes = {}
+    for name, field in form.fields.items():
+        # If the field is not in the data, then go on to the next one
+        try:
+            newValue = data[name]
+        except KeyError:
+            continue
+        # If the value is NOT_CHANGED, ignore it, since the widget/converter
+        # sent a strong message not to do so.
+        if newValue is NOT_CHANGED:
+            continue
+        if force or changedField(field.field, newValue, context=content):
+            # Only update the data, if it is different
+            dm = getMultiAdapter((content, field.field), IDataManager)
+            dm.set(newValue)
+            # Record the change using information required later
+            changes.setdefault(dm.field.interface, []).append(name)
+    return changes

--- a/plone/dexterity/tests/test_schema.py
+++ b/plone/dexterity/tests/test_schema.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from mock import Mock
-from pkg_resources import get_distribution
 from plone.dexterity import schema
 from plone.dexterity.fti import DexterityFTI
 from plone.dexterity.interfaces import IContentType
@@ -14,11 +13,7 @@ from zope.interface import Interface
 from zope.interface.interface import InterfaceClass
 from .case import MockTestCase
 
-import unittest
 import zope.schema
-
-
-has_zope4 = get_distribution('Zope2').version.startswith('4')
 
 
 class TestSchemaModuleFactory(MockTestCase):
@@ -156,7 +151,6 @@ class TestSchemaModuleFactory(MockTestCase):
             schema.portalTypeToSchemaName('type one.two', '', 'prefix')
         )
 
-    @unittest.skipIf(has_zope4, 'Broken with zope4, see https://community.plone.org/t/problems-with-mocktestcase-in-plone-dexterity/1484')  # noqa
     def test_portalTypeToSchemaName_looks_up_portal_for_prefix(self):
         portal_mock = Mock()
         portal_mock.getPhysicalPath = Mock(return_value=['', 'foo', 'portalid'])

--- a/plone/dexterity/tests/test_utils.py
+++ b/plone/dexterity/tests/test_utils.py
@@ -1,19 +1,12 @@
 # -*- coding: utf-8 -*-
 from mock import Mock
-from pkg_resources import get_distribution
 from plone.dexterity import utils
 from plone.dexterity.fti import DexterityFTI
 from .case import MockTestCase
 
-import unittest
-
-
-has_zope4 = get_distribution('Zope2').version.startswith('4')
-
 
 class TestUtils(MockTestCase):
 
-    @unittest.skipIf(has_zope4, 'Broken with zope4, see https://community.plone.org/t/problems-with-mocktestcase-in-plone-dexterity/1484')  # noqa
     def test_getAdditionalSchemata(self):
         from plone.dexterity.interfaces import IDexterityFTI
         from plone.behavior.interfaces import IBehavior

--- a/plone/dexterity/tests/test_views.py
+++ b/plone/dexterity/tests/test_views.py
@@ -124,8 +124,6 @@ class TestAddView(MockTestCase):
 
         provideAdapter(AttributeField)
 
-        self.replay()
-
         self.assertEqual(obj_dummy, form.create(data_dummy))
         self.assertEqual("testtype", obj_dummy.portal_type)
 

--- a/plone/dexterity/tests/test_views.py
+++ b/plone/dexterity/tests/test_views.py
@@ -21,10 +21,13 @@ from plone.dexterity.interfaces import IEditFinishedEvent
 from plone.dexterity.schema import SCHEMA_CACHE
 from plone.z3cform.interfaces import IDeferSecurityCheck
 from z3c.form.action import Actions
+from z3c.form.datamanager import AttributeField
+from z3c.form.field import Fields
 from z3c.form.field import FieldWidgets
 from z3c.form.interfaces import IActions
 from z3c.form.interfaces import IWidgets
 from zope.component import adapter
+from zope.component import provideAdapter
 from zope.container.interfaces import INameChooser
 from zope.interface import Interface
 from zope.interface import alsoProvides
@@ -32,6 +35,7 @@ from zope.interface import implementer
 from zope.interface import provider
 from zope.publisher.browser import TestRequest as TestRequestBase
 from .case import MockTestCase
+from zope import schema
 
 
 class TestRequest(TestRequestBase):
@@ -105,16 +109,22 @@ class TestAddView(MockTestCase):
         form = DefaultAddForm(context, request)
         form.portal_type = u"testtype"
 
+        class ISchema(Interface):
+            foo = schema.TextLine()
+        form.fields = Fields(ISchema)
+
         # createObject and applyChanges
 
         obj_dummy = Item(id="dummy")
+        alsoProvides(obj_dummy, ISchema)
         data_dummy = {u"foo": u"bar"}
 
         from zope.component import createObject
         self.patch_global(createObject, return_value=obj_dummy)
 
-        from z3c.form.form import applyChanges
-        self.patch_global(applyChanges)
+        provideAdapter(AttributeField)
+
+        self.replay()
 
         self.assertEqual(obj_dummy, form.create(data_dummy))
         self.assertEqual("testtype", obj_dummy.portal_type)


### PR DESCRIPTION
This fixes a bug where no value was stored if the value entered in the form is equal to the default value. That can then be quite annoying if the default is calculated in a defaultFactory that changes over time. For example if there is a defaultFactory which returns the current date, the value will always be read as today's date (because `__getattr__` also reads defaults) until the item is edited with a value other than the current day's date.

The fix is made by using our own copy of `applyChanges` (originally from z3c.form) which now takes a `force` boolean. The add form passes `force=True` to skip the comparison to the existing value and always store the new value, which is appropriate when adding a new object.