### PR TITLE
Provide the dublin core Format method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ New features:
 
 Bug fixes:
 
+- Provide the dublin core ``Format`` method in the ``DexterityContent`` class
+  [ale-rt]
 - Other Python 3 compatibility fixes
   [ale-rt, pbauer, jensens]
 

--- a/plone/dexterity/content.py
+++ b/plone/dexterity/content.py
@@ -1,24 +1,14 @@
 # -*- coding: utf-8 -*-
-from AccessControl import ClassSecurityInfo
 from AccessControl import Permissions as acpermissions
+from AccessControl import ClassSecurityInfo
 from AccessControl import getSecurityManager
-from Acquisition import Explicit
 from Acquisition import aq_base
 from Acquisition import aq_parent
+from Acquisition import Explicit
+from copy import deepcopy
 from DateTime import DateTime
 from OFS.PropertyManager import PropertyManager
 from OFS.SimpleItem import SimpleItem
-from Products.CMFCore import permissions
-from Products.CMFCore.CMFCatalogAware import CMFCatalogAware
-from Products.CMFCore.PortalContent import PortalContent
-from Products.CMFCore.PortalFolder import PortalFolderBase
-from Products.CMFCore.interfaces import ICatalogableDublinCore
-from Products.CMFCore.interfaces import IDublinCore
-from Products.CMFCore.interfaces import IMutableDublinCore
-from Products.CMFCore.interfaces import ITypeInformation
-from Products.CMFDynamicViewFTI.browserdefault import BrowserDefaultMixin
-from Products.CMFPlone.interfaces import IConstrainTypes
-from copy import deepcopy
 from plone.autoform.interfaces import READ_PERMISSIONS_KEY
 from plone.behavior.interfaces import IBehaviorAssignable
 from plone.dexterity.filerepresentation import DAVCollectionMixin
@@ -35,15 +25,25 @@ from plone.dexterity.utils import safe_utf8
 from plone.folder.ordered import CMFOrderedBTreeFolderBase
 from plone.uuid.interfaces import IAttributeUUID
 from plone.uuid.interfaces import IUUID
+from Products.CMFCore import permissions
+from Products.CMFCore.CMFCatalogAware import CMFCatalogAware
+from Products.CMFCore.interfaces import ICatalogableDublinCore
+from Products.CMFCore.interfaces import IDublinCore
+from Products.CMFCore.interfaces import IMutableDublinCore
+from Products.CMFCore.interfaces import ITypeInformation
+from Products.CMFCore.PortalContent import PortalContent
+from Products.CMFCore.PortalFolder import PortalFolderBase
+from Products.CMFDynamicViewFTI.browserdefault import BrowserDefaultMixin
+from Products.CMFPlone.interfaces import IConstrainTypes
 from zExceptions import Unauthorized
 from zope.annotation import IAttributeAnnotatable
 from zope.component import queryUtility
 from zope.container.contained import Contained
 from zope.interface import implementer
-from zope.interface.declarations import Implements
-from zope.interface.declarations import ObjectSpecificationDescriptor
 from zope.interface.declarations import getObjectSpecification
 from zope.interface.declarations import implementedBy
+from zope.interface.declarations import Implements
+from zope.interface.declarations import ObjectSpecificationDescriptor
 from zope.schema.interfaces import IContextAwareDefaultFactory
 from zope.security.interfaces import IPermission
 
@@ -538,6 +538,11 @@ class DexterityContent(DAVResourceMixin, PortalContent, PropertyManager,
     def Identifier(self):
         # Dublin Core Identifier element - resource ID.
         return self.absolute_url()
+
+    @security.protected(permissions.View)
+    def Format(self):
+        # Dublin Core Format element
+        return self.format or super(DexterityContent, self).Format()
 
     @security.protected(permissions.View)
     def Language(self):

--- a/plone/dexterity/tests/test_content.py
+++ b/plone/dexterity/tests/test_content.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
+from .case import MockTestCase
+from datetime import date
+from datetime import datetime
 from DateTime import DateTime
-from Products.CMFPlone.interfaces import IConstrainTypes
-from datetime import date, datetime
 from mock import Mock
 from plone.behavior.interfaces import IBehavior
 from plone.behavior.interfaces import IBehaviorAssignable
@@ -16,13 +17,13 @@ from plone.dexterity.interfaces import IDexterityFTI
 from plone.dexterity.schema import SCHEMA_CACHE
 from plone.folder.default import DefaultOrdering
 from Products.CMFCore.interfaces import ITypesTool
+from Products.CMFPlone.interfaces import IConstrainTypes
 from pytz import timezone
 from zope.annotation.attribute import AttributeAnnotations
 from zope.component import getUtility
 from zope.component import provideAdapter
-from zope.interface import Interface
 from zope.interface import alsoProvides
-from .case import MockTestCase
+from zope.interface import Interface
 
 import six
 import zope.schema
@@ -615,7 +616,7 @@ class TestContent(MockTestCase):
             contributors=u'admin',
             effective_date="08/20/2010",
             expiration_date="07/09/2013",
-            format='text/plain',
+            format='text/foo',
             language='de',
             rights='CC',
         )
@@ -630,7 +631,8 @@ class TestContent(MockTestCase):
         self.assertEqual(i.contributors, (u'admin',))
         self.assertEqual(i.listContributors(), ('admin',))
         self.assertEqual(i.Contributors(), ('admin',))
-        self.assertEqual(i.format, 'text/plain')
+        self.assertEqual(i.format, 'text/foo')
+        self.assertEqual(i.Format(), 'text/foo')
         self.assertEqual(i.effective_date, DateTime('08/20/2010'))
         self.assertEqual(
             i.EffectiveDate(zone=summer_timezone)[:10], '2010-08-20')


### PR DESCRIPTION
Provide the dublin core ``Format`` method in the ``DexterityContent`` class.
Before it was inherited by the DAVResourceMixin and was not returning
the format attribute but the output of the content_type() method