### PR TITLE
encode unicode message as utf-8, not default encoding

### DIFF
--- a/plone/dexterity/filerepresentation.py
+++ b/plone/dexterity/filerepresentation.py
@@ -690,10 +690,10 @@ class DefaultReadFile(ReadFileBase):
         message = self._getMessage()
         if six.PY2:
             # message.as_string will return str in both Python 2 and 3
-            mode = 'w+b'
+            kw = {'mode': 'w+b'}
         else:
-            mode = 'w+'
-        out = tempfile.TemporaryFile(mode=mode)
+            kw = {'mode': 'w+', 'encoding': 'utf-8'}
+        out = tempfile.TemporaryFile(**kw)
         out.write(message.as_string())
         self._size = out.tell()
         out.seek(0)


### PR DESCRIPTION
This fixes the failing testMakeSnapshot test