### PR TITLE
Fixed test for minor check_id change.

### DIFF
--- a/news/2582.trivial
+++ b/news/2582.trivial
@@ -1,0 +1,3 @@
+Fixed test for minor check_id change.
+
+We need the 'Access contents information' permission.

--- a/plone/dexterity/tests/test_utils.py
+++ b/plone/dexterity/tests/test_utils.py
@@ -52,6 +52,10 @@ class TestUtils(MockTestCase):
         from plone.dexterity.content import Container
         container = Container()
         container._ordering = u'unordered'
+        # Allow anyone to access the contents information on the container.
+        # This allows to check for existing content with the same id.
+        container.manage_permission(
+            'Access contents information', ['Anonymous'], acquire=1)
 
         from zope.component import provideAdapter, provideUtility
         from zope.container.interfaces import INameChooser


### PR DESCRIPTION
We need the 'Access contents information' permission.
https://github.com/plone/Products.CMFPlone/issues/2582

Should be fine to test and merge on its own, both on Plone 5.1 and 5.2, but it is meant to be tested in combination with a few other PRs from that issue.