### PR TITLE
Restore old __repr__

### DIFF
--- a/news/93.bugfix
+++ b/news/93.bugfix
@@ -1,0 +1,3 @@
+Add PathReprProvider as a baseclass of Container to restore the original __repr__ behavior instead of the new __repr__ from persistent.Persistent.
+PathReprProvider needs to be before CMFOrderedBTreeFolderBase (which inherits OrderedBTreeFolderBase > BTreeFolder2Base > Persistent).
+[pbauer]

--- a/plone/dexterity/content.py
+++ b/plone/dexterity/content.py
@@ -7,6 +7,7 @@ from Acquisition import aq_base
 from Acquisition import aq_parent
 from DateTime import DateTime
 from OFS.PropertyManager import PropertyManager
+from OFS.SimpleItem import PathReprProvider
 from OFS.SimpleItem import SimpleItem
 from Products.CMFCore import permissions
 from Products.CMFCore.CMFCatalogAware import CMFCatalogAware
@@ -678,6 +679,7 @@ class Item(PasteBehaviourMixin, BrowserDefaultMixin, DexterityContent):
 
 @implementer(IDexterityContainer)
 class Container(
+        PathReprProvider,
         PasteBehaviourMixin, DAVCollectionMixin, BrowserDefaultMixin,
         CMFCatalogAware, CMFOrderedBTreeFolderBase, DexterityContent):
     """Base class for folderish items


### PR DESCRIPTION
Replace the new `__repr__` in `persistent.Persistent` with the original one that includes the physical path by adding PathReprProvider as a Baseclass. 

See https://github.com/plone/Products.CMFPlone/issues/2590 for discussion