### PR TITLE
easier container selection in subclasses

### DIFF
--- a/news/101.feature
+++ b/news/101.feature
@@ -1,0 +1,1 @@
+Add container property to ``AddForm`` to simplify target container selection in subclasses. [jensens]


### PR DESCRIPTION
When having custom add form with target selection, the container selection results in overrides of too much code. Now with this change the container property just has to be overridden.