### PR TITLE
Fix WebDav GET and PUT on Python 3

### DIFF
--- a/news/102.bugfix
+++ b/news/102.bugfix
@@ -1,0 +1,1 @@
+Fix WebDAV compatibility issues with ZServer on Python 3 [datakurre]

--- a/plone/dexterity/filerepresentation.py
+++ b/plone/dexterity/filerepresentation.py
@@ -689,13 +689,11 @@ class DefaultReadFile(ReadFileBase):
         # publisher, which will serve it efficiently even after the
         # transaction is closed
         message = self._getMessage()
+        out = tempfile.TemporaryFile(mode='w+b')
         if six.PY2:
-            # message.as_string will return str in both Python 2 and 3
-            kw = {'mode': 'w+b'}
+            out.write(message.as_string())
         else:
-            kw = {'mode': 'w+', 'encoding': 'utf-8'}
-        out = tempfile.TemporaryFile(**kw)
-        out.write(message.as_string())
+            out.write(message.as_string().encode('utf-8'))
         self._size = out.tell()
         out.seek(0)
         return out

--- a/plone/dexterity/filerepresentation.py
+++ b/plone/dexterity/filerepresentation.py
@@ -836,7 +836,10 @@ class DefaultWriteFile(object):
         if self._closed:
             raise ValueError("File is closed")
         self._written += len(data)
-        self._parser.feed(data)
+        if isinstance(data, bytes):
+            self._parser.feed(data.decode('utf-8'))
+        else:
+            self._parser.feed(data)
 
     def writelines(self, sequence):
         for item in sequence:


### PR DESCRIPTION
I've started migrating ZServer to Python 3 by basing it on top of Twisted. While testing WebDAV with my development version, I noticed that Dexterity WebDAV support produces string data and expects string data even stream iterator interface expects it to deliver bytes. Similarly I expect that it also should support writing PUT from bytes.