### PR TITLE
[datakurre-no-getattr] Minor fixes for a couple of cornercases

### DIFF
--- a/plone/dexterity/utils.py
+++ b/plone/dexterity/utils.py
@@ -21,6 +21,7 @@ from zope.component import getUtility
 from zope.container.interfaces import INameChooser
 from zope.dottedname.resolve import resolve
 from zope.event import notify
+from zope.interface.interface import Method
 from zope.lifecycleevent import ObjectCreatedEvent
 from zope.schema.interfaces import IContextAwareDefaultFactory
 
@@ -248,7 +249,7 @@ def default_from_schema(context, schema, fieldname, default=_marker):
     if schema is None:
         return default
     field = schema.get(fieldname, None)
-    if field is None:
+    if field is None or isinstance(field, Method):
         return default
     if IContextAwareDefaultFactory.providedBy(
         getattr(field, 'defaultFactory', None)

--- a/plone/dexterity/utils.py
+++ b/plone/dexterity/utils.py
@@ -279,7 +279,7 @@ def initialize_missing_attributes(context):
         if behavior is not content:
             # we only care about direct content attributes
             continue
-        for name in schema.names():
+        for name in schema.names(all=True):
             try:
                 # hasattr swallows exceptions
                 object.__getattribute__(behavior, name)


### PR DESCRIPTION
**For random potential pull request reviewers** note that this branch does **NOT** target any regular branch used by any Plone version. It targets a branch created by @datakurre that improves the performance of `plone.dexterity` by avoiding the expensive `__getattr__`.

This pull request itself only adds some *icyng on top* by fixing a couple of corner cases, which are already explained on the commit messages themselves.