### PR TITLE
WIP: Fix lineage recursion

### DIFF
--- a/plone/dexterity/content.py
+++ b/plone/dexterity/content.py
@@ -16,6 +16,7 @@ from plone.dexterity.filerepresentation import DAVCollectionMixin
 from plone.dexterity.filerepresentation import DAVResourceMixin
 from plone.dexterity.interfaces import IDexterityContainer
 from plone.dexterity.interfaces import IDexterityContent
+from plone.dexterity.interfaces import IDexterityFTI
 from plone.dexterity.interfaces import IDexterityItem
 from plone.dexterity.schema import SCHEMA_CACHE
 from plone.dexterity.utils import all_merged_tagged_values_dict
@@ -62,6 +63,7 @@ ATTRIBUTE_NAMES_TO_IGNORE = (
     'im_self',  # python 2 only, on python 3 it was renamed to __self__
     'aq_inner',
     '_Access_contents_information_Permission'
+    'portal_factory',
 )
 
 
@@ -122,9 +124,10 @@ class FTIAwareSpecification(ObjectSpecificationDescriptor):
         #  - The FTI was modified.
         #  - The instance was modified and persisted since the cache was built.
         #  - The instance has a different direct specification.
+        fti = queryUtility(IDexterityFTI, name=portal_type, default=None)
         updated = (
             inst._p_mtime,
-            SCHEMA_CACHE.modified(portal_type),
+            SCHEMA_CACHE.modified(fti or portal_type),
             SCHEMA_CACHE.invalidations,
             hash(direct_spec)
         )


### PR DESCRIPTION
This is a WIP to test a possible fix for a recursion problem that is happening with https://github.com/collective/lineage.registry and https://github.com/zopefoundation/five.localsitemanager.

The problem is that when the active site is a non local dexterity object, whenever a utility is fetched the attributes/methods are read from the dexterity object. 

That means that the schema cache is checked for modification.
If we pass the portal_type as a string a queryUtility call for the FTI is made, triggering a loop:
https://github.com/plone/plone.dexterity/blob/903795b86d148ac8f1eba19332f1ba658bcede98/plone/dexterity/schema.py#L55-L58
Passing the fti directly to the cache method fixes the loop.

This is a WIP I will try to add some test, but I am not sure it will be that easy.


