### PR TITLE
Speedup schema cache and contents __getattr__

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,25 @@
 language: python
+dist: xenial
 python: 2.7
 sudo: false
 cache:
+  pip: true
   directories:
     - eggs
-env:
-  - PLONE_VERSION=5.0
-  - PLONE_VERSION=5.1
 matrix:
-  allow_failures:
+  include:
+    - env: PLONE_VERSION=5.0
+      python: "2.7"
     - env: PLONE_VERSION=5.1
+      python: "2.7"
+    - env: PLONE_VERSION=5.2
+      python: "2.7"
+    - env: PLONE_VERSION=5.2
+      python: "3.7"
   fast_finish: true
 install:
   - sed -ie "s#test-5.0#test-$PLONE_VERSION#" buildout.cfg
-  - pip install setuptools==33.1.1
-  - pip install zc.buildout==2.8.0
-  - buildout bootstrap .
-  - bin/buildout annotate
-  - bin/buildout -Nv install test
+  - pip install -r https://dist.plone.org/release/$PLONE_VERSION-latest/requirements.txt
+  - buildout annotate
+  - buildout -Nv install test
 script: bin/test

--- a/news/113.bugfix
+++ b/news/113.bugfix
@@ -1,0 +1,2 @@
+Performance enhancement in schema cache by factor ~1.5.
+[jensens]

--- a/news/113.bugfix
+++ b/news/113.bugfix
@@ -1,2 +1,2 @@
-Performance enhancement in schema cache by factor ~1.5.
+Performance enhancement in schema cache and assignable.
 [jensens]

--- a/plone/dexterity/tests/test_fti.py
+++ b/plone/dexterity/tests/test_fti.py
@@ -454,7 +454,7 @@ class TestFTIEvents(MockTestCase):
         setSite(site_dummy)
         setHooks()
 
-        self.assertNotEquals(
+        self.assertNotEqual(
             None,
             queryUtility(IDexterityFTI, name=portal_type)
         )
@@ -618,7 +618,7 @@ class TestFTIEvents(MockTestCase):
         )
 
         # Then look for re-registration of global components
-        self.assertEquals(site_manager_mock.registerUtility.call_count, 2)
+        self.assertEqual(site_manager_mock.registerUtility.call_count, 2)
 
         site_dummy = self.create_dummy(
             getSiteManager=lambda: site_manager_mock

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         'zope.component',
         'zope.container',
         'zope.dottedname',
+        'zope.globalrequest',
         'zope.filerepresentation>=3.6.0',
         'zope.interface',
         'zope.lifecycleevent',


### PR DESCRIPTION
1. in schema cache, By first checking for string, the `providedBy` can be avoided. Since this function is called really often it makes a difference. According to my profiling its speeds up plone/dexterity/schema.py function decorator by factor ~1.54x.
2. in schema cache, the FTI itself can be cached on the request. Using the cache is twice as fast as the lookup itself.
3. in content `__getattr__` the BehaviorAssignable lookup is expensive and done very often. Do it once per type and save a lot of time. Speedup factor ~1.9x

If found this on my the hunt for the slowness of `unrestrictedTraverse`. A simple traversal to `/Plone/news/aggregator` repeating it a bunch of times was my test bed. 

TL;DR: 

profiling before:
```
10000 0.158 3.438 /home/jensens/.buildout/shared-eggs/Zope-4.1.1-py3.7.egg/OFS/Traversable.py:152(unrestrictedTraverse)
50002/30000 0.373 2.530 /home/jensens/workspace/cdev/plone5.2/src/plone.dexterity/plone/dexterity/content.py:333(__getattr__)
```
after:
```
10000 0.115 1.231 /home/jensens/.buildout/shared-eggs/Zope-4.1.1-py3.7.egg/OFS/Traversable.py:152(unrestrictedTraverse)
30003/30000 0.179 0.572 /home/jensens/workspace/cdev/plone5.2/src/plone.dexterity/plone/dexterity/content.py:336(__getattr__)
```

Overall performance gain in my profiling test: ~2.8x
