### PR TITLE
Performance: Cache expensive assignable lookup

### DIFF
--- a/news/115.bugfix
+++ b/news/115.bugfix
@@ -1,0 +1,2 @@
+Performance enhancement in schema cache and assignable.
+[jensens]


### PR DESCRIPTION
in content __getattr__ the BehaviorAssignable lookup is expensive and done very often. Do it once per type and save a lot of time. Speedup factor ~1.9x

see also #113