### PR TITLE
Performance: avoid a providedBy in _default_from_schema

### DIFF
--- a/news/117.bugfix
+++ b/news/117.bugfix
@@ -1,0 +1,2 @@
+Performance enhancement: avoid a providedBy in ``_default_from_schema``.
+[jensens]

--- a/plone/dexterity/content.py
+++ b/plone/dexterity/content.py
@@ -73,14 +73,14 @@ def _default_from_schema(context, schema, fieldname):
     field = schema.get(fieldname, None)
     if field is None:
         return _marker
-    if IContextAwareDefaultFactory.providedBy(
-            getattr(field, 'defaultFactory', None)
+    default_factory = getattr(field, 'defaultFactory', None)
+    if (
+        # check for None to avoid one expensive providedBy (called often)
+        default_factory is not None and
+        IContextAwareDefaultFactory.providedBy(default_factory)
     ):
-        bound = field.bind(context)
-        return deepcopy(bound.default)
-    else:
-        return deepcopy(field.default)
-    return _marker
+        return deepcopy(field.bind(context).default)
+    return deepcopy(field.default)
 
 
 class FTIAwareSpecification(ObjectSpecificationDescriptor):


### PR DESCRIPTION
Avoids an expensive ``providedBy`` in ``_default_from_schema``. Usually no need to call if there is no defaultFactory.