### PR TITLE
fix: thread safe recursion detection

### DIFF
--- a/news/120.bugfix
+++ b/news/120.bugfix
@@ -1,0 +1,1 @@
+- Fix thread safe recursion detection. This fixes an issue in plone.restapi: https://github.com/plone/plone.dexterity/issues/120. [jensens]

--- a/plone/dexterity/content.py
+++ b/plone/dexterity/content.py
@@ -50,10 +50,12 @@ from zope.schema.interfaces import IContextAwareDefaultFactory
 from zope.security.interfaces import IPermission
 
 import six
+import threading
 
 
 _marker = object()
 _zone = DateTime().timezone()
+_recursion_detection = threading.local()
 FLOOR_DATE = DateTime(1970, 0)  # always effective
 CEILING_DATE = DateTime(2500, 0)  # never expires
 
@@ -128,13 +130,12 @@ class FTIAwareSpecification(ObjectSpecificationDescriptor):
         if inst is None:
             return getObjectSpecification(cls)
 
-        direct_spec = getattr(inst, '__provides__', None)
+        # get direct specification
+        spec = getattr(inst, '__provides__', None)
 
         # avoid recursion - fall back on default
-        if getattr(self, '__recursion__', False):
-            return direct_spec
-
-        spec = direct_spec
+        if getattr(_recursion_detection, 'blocked', False):
+            return spec
 
         # If the instance doesn't have a __provides__ attribute, get the
         # interfaces implied by the class as a starting point.
@@ -161,7 +162,7 @@ class FTIAwareSpecification(ObjectSpecificationDescriptor):
             inst._p_mtime,
             SCHEMA_CACHE.modified(portal_type),
             SCHEMA_CACHE.invalidations,
-            hash(direct_spec)
+            hash(spec)
         )
         if cache is not None and cache[:-1] == updated:
             if cache[-1] is not None:
@@ -175,7 +176,7 @@ class FTIAwareSpecification(ObjectSpecificationDescriptor):
             dynamically_provided = []
 
         # block recursion
-        self.__recursion__ = True
+        setattr(_recursion_detection, 'blocked', True)
         try:
             assignable = get_assignable(inst)
             if assignable is not None:
@@ -185,7 +186,7 @@ class FTIAwareSpecification(ObjectSpecificationDescriptor):
                             behavior_registration.marker
                         )
         finally:
-            del self.__recursion__
+            setattr(_recursion_detection, 'blocked', False)
 
         if not dynamically_provided:
             # rare case if no schema nor behaviors with markers are set


### PR DESCRIPTION
@tisto asked me to emergency debug a problem that occurs in one of his current Volto projects and this is the outcome.

**Problem**: 
With `plone.restapi` and a lot of small requests in parallel errors like this did pop up randomly with random interfaces:
```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 155, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 337, in publish_module
  Module ZPublisher.WSGIPublisher, line 255, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 61, in call_object
  Module plone.rest.service, line 23, in __call__
  Module plone.restapi.services, line 21, in render
  Module plone.restapi.services.content.get, line 18, in reply
  Module plone.restapi.serializer.dxcontent, line 125, in __call__
  Module plone.restapi.serializer.dxcontent, line 83, in __call__
  Module plone.restapi.serializer.dxfields, line 41, in __call__
  Module plone.restapi.serializer.dxfields, line 31, in get_value
  Module zope.interface.interface, line 143, in __call__
TypeError: ('Could not adapt', <FolderishDocument at /Plone/de/foo>, <SchemaClass plone.app.dexterity.behaviors.discussion.IAllowDiscussion>)
```
After reading lots of code and debugging for while I was able to boil it down to a `providedBy` call. It happens only if there are a lot `providedBy` calls in parallel. In debugger or in tests this condition was not reproducible, only @tisto s test instance produced the effect. Also it did not occur in single threaded Zope instances.

**Solution:**
Finally I looked for places where caches or similar where shared, because it smells like somethings not thread safe and pollutes the other side. After a bit of code review I found that `zope.interface` here has clean code and then I thought about Dexterity/Behavior caches since we are caching here a lot of things. At the end it was not a cache, but the recursion detection code which was not thread safe. Using a thread-local here solves the problem. 

I have no idea how to write a test for this scenario. I am open for ideas. Otherwise I propose to merge this PR w/o am additional test.