### PR TITLE
Threadsafe recursion detection backport

### DIFF
--- a/news/120.bugfix
+++ b/news/120.bugfix
@@ -1,0 +1,1 @@
+- Fix thread safe recursion detection. This fixes an issue in plone.restapi: https://github.com/plone/plone.dexterity/issues/120. (Backport of https://github.com/plone/plone.dexterity/pull/119) [jensens]

--- a/plone/dexterity/content.py
+++ b/plone/dexterity/content.py
@@ -48,10 +48,12 @@ from zope.schema.interfaces import IContextAwareDefaultFactory
 from zope.security.interfaces import IPermission
 
 import six
+import threading
 
 
 _marker = object()
 _zone = DateTime().timezone()
+_recursion_detection = threading.local()
 FLOOR_DATE = DateTime(1970, 0)  # always effective
 CEILING_DATE = DateTime(2500, 0)  # never expires
 
@@ -84,13 +86,12 @@ class FTIAwareSpecification(ObjectSpecificationDescriptor):
         if inst is None:
             return getObjectSpecification(cls)
 
-        direct_spec = getattr(inst, '__provides__', None)
+        # get direct specification
+        spec = getattr(inst, '__provides__', None)
 
         # avoid recursion - fall back on default
-        if getattr(self, '__recursion__', False):
-            return direct_spec
-
-        spec = direct_spec
+        if getattr(_recursion_detection, 'blocked', False):
+            return spec
 
         # If the instance doesn't have a __provides__ attribute, get the
         # interfaces implied by the class as a starting point.
@@ -117,7 +118,7 @@ class FTIAwareSpecification(ObjectSpecificationDescriptor):
             inst._p_mtime,
             SCHEMA_CACHE.modified(portal_type),
             SCHEMA_CACHE.invalidations,
-            hash(direct_spec)
+            hash(spec)
         )
         if cache is not None and cache[:-1] == updated:
             if cache[-1] is not None:
@@ -131,7 +132,7 @@ class FTIAwareSpecification(ObjectSpecificationDescriptor):
             dynamically_provided = []
 
         # block recursion
-        self.__recursion__ = True
+        setattr(_recursion_detection, 'blocked', True)
         try:
             assignable = IBehaviorAssignable(inst, None)
             if assignable is not None:
@@ -141,7 +142,7 @@ class FTIAwareSpecification(ObjectSpecificationDescriptor):
                             behavior_registration.marker
                         )
         finally:
-            del self.__recursion__
+            setattr(_recursion_detection, 'blocked', False)
 
         if not dynamically_provided:
             # rare case if no schema nor behaviors with markers are set


### PR DESCRIPTION
Same as https://github.com/plone/plone.dexterity/pull/119 but for 2.6.x (Plone 5.1.x)