### PR TITLE
fix: reset fti cache on request

### DIFF
--- a/news/122.bugfix
+++ b/news/122.bugfix
@@ -1,0 +1,1 @@
+Invalidate cached FTIs on request to allow complex/long running auto-installations. [jensens]


### PR DESCRIPTION
The problem reported by @tisto in https://github.com/plone/plone.dexterity/pull/119#issuecomment-568525387 is due to a missing cache invalidation. In a normal request-response cycle the request as a place for an FTI cache does not need invalidation. But on long running imports like content generation with `collective.contentcreator` in combination with `collective.recipe.plonesite` - where is just one request over the whole lifetime - invalidation is needed. I refactored the code to make it more readable and added the missing invalidation.