### PR TITLE
Speedup parallel threads by removing superfluos synchronization

### DIFF
--- a/news/123.bugfix
+++ b/news/123.bugfix
@@ -1,0 +1,1 @@
+Speedup (~1.6x) parallel thread execution by removing superfluos synchronization [jensens]

--- a/plone/dexterity/schema.py
+++ b/plone/dexterity/schema.py
@@ -145,7 +145,6 @@ class SchemaCache(object):
         self.cache_enabled = cache_enabled
         self.invalidations = 0
 
-    @synchronized(lock)
     @volatile
     def get(self, fti):
         """main schema
@@ -159,7 +158,6 @@ class SchemaCache(object):
             except (AttributeError, ValueError):
                 pass
 
-    @synchronized(lock)
     @volatile
     def behavior_registrations(self, fti):
         """all behavior behavior registrations of a given fti passed in as
@@ -204,7 +202,6 @@ class SchemaCache(object):
             registrations.append(registration)
         return tuple(registrations)
 
-    @synchronized(lock)
     @volatile
     def subtypes(self, fti):
         """all registered marker interfaces of ftis behaviors
@@ -220,7 +217,6 @@ class SchemaCache(object):
                 subtypes.append(behavior_registration.marker)
         return tuple(subtypes)
 
-    @synchronized(lock)
     @volatile
     def behavior_schema_interfaces(self, fti):
         """behavior schema interfaces registered for the fti
@@ -236,7 +232,6 @@ class SchemaCache(object):
                 schemas.append(behavior_registration.interface)
         return tuple(schemas)
 
-    @synchronized(lock)
     @volatile
     def schema_interfaces(self, fti):
         """all schema interfaces registered for the fti
@@ -273,7 +268,6 @@ class SchemaCache(object):
             invalidate_cache(fti)
             self.invalidations += 1
 
-    @synchronized(lock)
     @volatile
     def modified(self, fti):
         if fti:


### PR DESCRIPTION
While debugging the latest problems of @tisto s Volto project I found possible (meanwhile) superfluos thread synchonizations. Volto in some scenarios creates lots of parallel small and short requests via `plone.restapi`. Blocking makes the thread idle and waiting where not needed, even if this is only a very short time (in low ms area) this happens often an accumulates. This is relevant for high traffic classic Plone sites too.

In Py-Spy with a real world Volto project the main-page timings before are:

```
  0.00%   0.00%   0.000s    21.08s   render (plone/restapi/services/__init__.py:21)
  0.00%   0.00%   0.000s    19.53s   reply (plone/restapi/services/content/get.py:18)
  0.00%   0.00%   0.000s    18.79s   __call__ (plone/restapi/serializer/dxcontent.py:125)
  0.00%   0.00%   0.000s    14.30s   __call__ (plone/restapi/serializer/dxcontent.py:83)
```
after this changes:
```
  0.00%   0.00%   0.000s    13.59s   render (plone/restapi/services/__init__.py:21)
  0.00%   0.00%   0.010s    12.41s   reply (plone/restapi/services/content/get.py:18)
  0.00%   0.00%   0.000s    11.72s   __call__ (plone/restapi/serializer/dxcontent.py:125)
  0.00%   0.00%   0.000s     8.87s   __call__ (plone/restapi/serializer/dxcontent.py:83)
```