### PR TITLE
Fixed package install error with Python 3.6 without system locale.

### DIFF
--- a/news/642.bugfix
+++ b/news/642.bugfix
@@ -1,0 +1,3 @@
+Fixed package install error with Python 3.6 without system locale.
+See `coredev issue 642 <https://github.com/plone/buildout.coredev/issues/642#issuecomment-597008272>`_.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,26 @@ from setuptools import setup
 
 version = '2.9.6.dev0'
 
+
+def read(filename):
+    with open(filename) as myfile:
+        try:
+            return myfile.read()
+        except UnicodeDecodeError:
+            # Happens on one Jenkins node on Python 3.6,
+            # so maybe it happens for users too.
+            pass
+    # Opening and reading as text failed, so retry opening as bytes.
+    with open(filename, "rb") as myfile:
+        contents = myfile.read()
+        return contents.decode("utf-8")
+
 short_description = """\
 Framework for content types as filesystem code and TTW (Zope/CMF/Plone)\
 """
-long_description = open("README.rst").read() + "\n"
-long_description += open("CHANGES.rst").read()
+long_description = read("README.rst")
+long_description += "\n"
+long_description += read("CHANGES.rst")
 
 setup(
     name='plone.dexterity',


### PR DESCRIPTION
See https://github.com/plone/buildout.coredev/issues/642#issuecomment-597008272

Also, this opens the readme and changelog in a context manager, so no files are left open.