### PR TITLE
Removed call of listing macro in content-core view for containers.

### DIFF
--- a/news/3177.bugfix
+++ b/news/3177.bugfix
@@ -1,0 +1,4 @@
+Removed call of listing macro in ``content-core`` view for containers.
+It was broken.  We now show the same as for items: only the fields.
+Fixes `issue 3177 <https://github.com/plone/Products.CMFPlone/issues/3177>`_.
+[maurits]

--- a/plone/dexterity/browser/configure.zcml
+++ b/plone/dexterity/browser/configure.zcml
@@ -13,7 +13,10 @@
         />
 
     <!-- Content core views -->
-
+    <!-- Note: the templaces are the same since the changes for
+         https://github.com/plone/Products.CMFPlone/issues/3177
+         That may be okay: makes it easier to customize
+         only the template for items or for containers. -->
     <browser:page
         for="..interfaces.IDexterityItem"
         name="content-core"

--- a/plone/dexterity/browser/containercontentcore.pt
+++ b/plone/dexterity/browser/containercontentcore.pt
@@ -18,11 +18,4 @@
       </div>
   </fieldset>
 
-  <fieldset id="folder-listing">
-      <legend>Contents</legend>
-      <tal:block define="listing_macro context/folder_listing/macros/listing">
-          <metal:use_macro use-macro="listing_macro" />
-      </tal:block>
-  </fieldset>
-
 </metal:content-core>


### PR DESCRIPTION
It was broken.
We now show the same as for items: only the fields.
Fixes https://github.com/plone/Products.CMFPlone/issues/3177.
Please check there for possible discussion on what the best solution is.

Looks like in core only `plone.app.versioningbehavior` calls this view.