### PR TITLE
Removed zope.interface pin from buildout.cfg.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -8,4 +8,3 @@ develop = .
 
 [versions]
 plone.dexterity =
-zope.interface = 4.7.1


### PR DESCRIPTION
Should fix Travis.

It [failed](https://travis-ci.org/github/plone/plone.dexterity/jobs/727675512) with:

```
Error: The requirement ('zope.interface>=5.0.0') is not allowed by your [versions] constraint (4.7.1)
```
