### PR TITLE
Fixed missing ISiteRoot utility when running tests with Zope 5.

### DIFF
--- a/news/680.bugfix
+++ b/news/680.bugfix
@@ -1,0 +1,2 @@
+Fixed missing ISiteRoot utility when running tests with Zope 5.
+[maurits]

--- a/plone/dexterity/tests/test_views.py
+++ b/plone/dexterity/tests/test_views.py
@@ -20,6 +20,7 @@ from plone.dexterity.interfaces import IEditCancelledEvent
 from plone.dexterity.interfaces import IEditFinishedEvent
 from plone.dexterity.schema import SCHEMA_CACHE
 from plone.z3cform.interfaces import IDeferSecurityCheck
+from Products.CMFCore.interfaces import ISiteRoot
 from Products.statusmessages.interfaces import IStatusMessage
 from z3c.form.action import Actions
 from z3c.form.datamanager import AttributeField
@@ -125,6 +126,9 @@ class TestAddView(MockTestCase):
         self.patch_global(createObject, return_value=obj_dummy)
 
         provideAdapter(AttributeField)
+
+        portal = self.create_dummy(getPhysicalPath=lambda: ('', 'site'))
+        self.mock_utility(portal, ISiteRoot)
 
         self.assertEqual(obj_dummy, form.create(data_dummy))
         self.assertEqual("testtype", obj_dummy.portal_type)


### PR DESCRIPTION
You get this error once:

```
Error in test test_form_create (plone.dexterity.tests.test_views.TestAddView)
Traceback (most recent call last):
  File "/Users/maurits/.pyenv/versions/3.8.5/lib/python3.8/unittest/case.py", line 60, in testPartExecutor
    yield
  File "/Users/maurits/.pyenv/versions/3.8.5/lib/python3.8/unittest/case.py", line 676, in run
    self._callTestMethod(testMethod)
  File "/Users/maurits/.pyenv/versions/3.8.5/lib/python3.8/unittest/case.py", line 633, in _callTestMethod
    method()
  File "/Users/maurits/community/plone-coredev/6.0/src/plone.dexterity/plone/dexterity/tests/test_views.py", line 129, in test_form_create
    self.assertEqual(obj_dummy, form.create(data_dummy))
  File "/Users/maurits/community/plone-coredev/6.0/src/plone.dexterity/plone/dexterity/browser/add.py", line 79, in create
    if IAcquirer.providedBy(content):
  File "/Users/maurits/community/plone-coredev/6.0/src/plone.dexterity/plone/dexterity/content.py", line 172, in __get__
    main_schema = SCHEMA_CACHE.get(portal_type)
  File "/Users/maurits/community/plone-coredev/6.0/src/plone.dexterity/plone/dexterity/schema.py", line 110, in decorator
    value = func(self, fti)
  File "/Users/maurits/community/plone-coredev/6.0/src/plone.dexterity/plone/dexterity/schema.py", line 157, in get
    return fti.lookupSchema()
  File "/Users/maurits/community/plone-coredev/6.0/src/plone.dexterity/plone/dexterity/fti.py", line 268, in lookupSchema
    schemaName = portalTypeToSchemaName(self.getId())
  File "/Users/maurits/community/plone-coredev/6.0/src/plone.dexterity/plone/dexterity/schema.py", line 328, in portalTypeToSchemaName
    prefix = '/'.join(getUtility(ISiteRoot).getPhysicalPath())[1:]
  File "/Users/maurits/shared-eggs/cp38/zope.component-4.6.2-py3.8.egg/zope/component/_api.py", line 165, in getUtility
    raise ComponentLookupError(interface, name)
zope.interface.interfaces.ComponentLookupError: (<InterfaceClass Products.CMFCore.interfaces.ISiteRoot>, '')
```

Note that this is in a true unittest without layers, so without any Plone Site being setup.
So the test failure seems innocent.
The fix is to mock the site root in the same way as we already do in lots of other tests.

I don't know why this fails with Zope 5.
It could be because Zope 5 recently upgraded zope.interface to 5.1.0.

Strangely, I have the same error locally on Plone 5.2 Python 2.7. This fix helps there as well.