### PR TITLE
Fix export/import of content in Python 3.

### DIFF
--- a/news/124.bugfix
+++ b/news/124.bugfix
@@ -1,0 +1,4 @@
+Fix export/import of content in Python 3.
+Fixes `issue 124 <https://github.com/plone/plone.dexterity/issues/124>`_.
+Also fixes the tests in combination with newest ``Products.GenericSetup`` 2.1.2.
+[maurits]

--- a/plone/dexterity/tests/test_exportimport.py
+++ b/plone/dexterity/tests/test_exportimport.py
@@ -38,7 +38,7 @@ class ExportImportTests(unittest.TestCase):
         item = DummyItem('test')
 
         import_context = DummyImportContext(None)
-        import_context._files['.data'] = 'title: Foo'
+        import_context._files['.data'] = b'title: Foo'
         importer = DexterityContentExporterImporter(item)
         importer.import_(import_context, None, root=True)
 


### PR DESCRIPTION
Fixes https://github.com/plone/plone.dexterity/issues/124

Also fixes the tests in combination with newest `Products.GenericSetup` 2.1.2.
In fact, with this fix they now fail with earlier versions. I don't think there is a benefit to specifying this in `setup.py` though.

This takes over the recent changes from GenericSetup, which is where we originally copied this import code from.
See also https://github.com/plone/plone.dexterity/pull/125#issuecomment-864995253