### PR TITLE
Fix recursion in FTI lookup

### DIFF
--- a/news/155.bugfix
+++ b/news/155.bugfix
@@ -1,2 +1,2 @@
-Fix recursion error when lookup IDexterityFTI for `Plone Site`
+Catch maximum recursion error when lookup FTI
 [petschki]

--- a/news/155.bugfix
+++ b/news/155.bugfix
@@ -1,0 +1,2 @@
+Fix recursion error when lookup IDexterityFTI for `Plone Site`
+[petschki]

--- a/plone/dexterity/content.py
+++ b/plone/dexterity/content.py
@@ -154,7 +154,6 @@ class FTIAwareSpecification(ObjectSpecificationDescriptor):
         if fti is None:
             fti = queryUtility(IDexterityFTI, name=portal_type)
             if fti is None:
-                print(f"No FTI found for {portal_type}")
                 return spec
             setattr(inst, "_v__cached_fti", fti)
 

--- a/plone/dexterity/content.py
+++ b/plone/dexterity/content.py
@@ -16,7 +16,6 @@ from plone.dexterity.filerepresentation import DAVCollectionMixin
 from plone.dexterity.filerepresentation import DAVResourceMixin
 from plone.dexterity.interfaces import IDexterityContainer
 from plone.dexterity.interfaces import IDexterityContent
-from plone.dexterity.interfaces import IDexterityFTI
 from plone.dexterity.interfaces import IDexterityItem
 from plone.dexterity.schema import SCHEMA_CACHE
 from plone.dexterity.utils import all_merged_tagged_values_dict
@@ -62,7 +61,6 @@ CEILING_DATE = DateTime(2500, 0)  # never expires
 
 # see comment in DexterityContent.__getattr__ method
 ATTRIBUTE_NAMES_TO_IGNORE = (
-    "_v__cached_fti",
     "_dav_writelocks",
     "aq_inner",
     "getCurrentSkinName",
@@ -150,42 +148,38 @@ class FTIAwareSpecification(ObjectSpecificationDescriptor):
         if portal_type is None:
             return spec
 
-        fti = getattr(inst, "_v__cached_fti", None)
-        if fti is None:
-            fti = queryUtility(IDexterityFTI, name=portal_type)
-            if fti is None:
-                return spec
-            setattr(inst, "_v__cached_fti", fti)
-
         # Find the cached value. This calculation is expensive and called
         # hundreds of times during each request, so we require a fast cache
         cache = getattr(inst, "_v__providedBy__", None)
-
-        # See if we have a current cache. Reasons to do this include:
-        #
-        #  - The FTI was modified.
-        #  - The instance was modified and persisted since the cache was built.
-        #  - The instance has a different direct specification.
-        updated = (
-            inst._p_mtime,
-            SCHEMA_CACHE.modified(fti),
-            SCHEMA_CACHE.invalidations,
-            hash(spec),
-        )
-        if cache is not None and cache[:-1] == updated:
-            if cache[-1] is not None:
-                return cache[-1]
-            return spec
-
-        main_schema = SCHEMA_CACHE.get(fti)
-        if main_schema:
-            dynamically_provided = [main_schema]
-        else:
-            dynamically_provided = []
+        updated = ()
+        dynamically_provided = []
 
         # block recursion
         setattr(_recursion_detection, "blocked", True)
         try:
+            # See if we have a current cache. Reasons to do this include:
+            #
+            #  - The FTI was modified.
+            #  - The instance was modified and persisted since the cache was built.
+            #  - The instance has a different direct specification.
+            updated = (
+                inst._p_mtime,
+                SCHEMA_CACHE.modified(portal_type),
+                SCHEMA_CACHE.invalidations,
+                hash(spec),
+            )
+            if cache is not None and cache[:-1] == updated:
+                setattr(_recursion_detection, "blocked", False)
+                if cache[-1] is not None:
+                    return cache[-1]
+                return spec
+
+            main_schema = SCHEMA_CACHE.get(portal_type)
+            if main_schema:
+                dynamically_provided = [main_schema]
+            else:
+                dynamically_provided = []
+
             assignable = get_assignable(inst)
             if assignable is not None:
                 for behavior_registration in assignable.enumerateBehaviors():

--- a/plone/dexterity/tests/case.py
+++ b/plone/dexterity/tests/case.py
@@ -6,7 +6,7 @@ import six
 import unittest
 import zope.component
 import zope.component.testing
-
+import zope.globalrequest
 
 try:
     from unittest.mock import Mock
@@ -24,6 +24,8 @@ class MockTestCase(unittest.TestCase):
 
     def tearDown(self):
         zope.component.testing.tearDown(self)
+        zope.globalrequest.setRequest(None)
+
         if self._replaced_globals is not None:
             for mock, orig in self._replaced_globals.items():
                 _global_replace(mock, orig)

--- a/plone/dexterity/tests/test_content.py
+++ b/plone/dexterity/tests/test_content.py
@@ -24,6 +24,8 @@ from zope.component import getUtility
 from zope.component import provideAdapter
 from zope.interface import alsoProvides
 from zope.interface import Interface
+from zope.globalrequest import setRequest
+from zope.publisher.browser import TestRequest
 
 import six
 import zope.schema
@@ -42,6 +44,7 @@ except ImportError:
 
 class TestContent(MockTestCase):
     def setUp(self):
+        setRequest(TestRequest())
         SCHEMA_CACHE.clear()
         provideAdapter(DefaultOrdering)
         provideAdapter(AttributeAnnotations)
@@ -74,6 +77,7 @@ class TestContent(MockTestCase):
         fti_mock = Mock(wraps=DexterityFTI("testtype"))
         fti_mock.lookupSchema = Mock(return_value=ISchema)
         self.mock_utility(fti_mock, IDexterityFTI, name=u"testtype")
+        alsoProvides(fti_mock, IDexterityFTI)
 
         self.assertFalse(ISchema.implementedBy(Item))
 
@@ -129,6 +133,7 @@ class TestContent(MockTestCase):
         fti_mock = Mock(wraps=DexterityFTI(u"testtype"))
         fti_mock.lookupSchema = Mock(return_value=ISchema)
         self.mock_utility(fti_mock, IDexterityFTI, name=u"testtype")
+        alsoProvides(fti_mock, IDexterityFTI)
 
         self.assertFalse(ISchema.implementedBy(MyItem))
 
@@ -175,6 +180,7 @@ class TestContent(MockTestCase):
         fti_mock = Mock(wraps=DexterityFTI(u"testtype"))
         fti_mock.lookupSchema = Mock(return_value=ISchema)
         self.mock_utility(fti_mock, IDexterityFTI, name=u"testtype")
+        alsoProvides(fti_mock, IDexterityFTI)
 
         self.assertFalse(ISchema.implementedBy(MyItem))
 
@@ -358,6 +364,7 @@ class TestContent(MockTestCase):
         fti_mock = Mock(wraps=DexterityFTI(u"testtype"))
         fti_mock.lookupSchema = Mock(return_value=ISchema)
         self.mock_utility(fti_mock, IDexterityFTI, name=u"testtype")
+        alsoProvides(fti_mock, IDexterityFTI)
 
         # start clean
         SCHEMA_CACHE.invalidate("testtype")
@@ -411,6 +418,7 @@ class TestContent(MockTestCase):
         fti_mock = Mock(wraps=DexterityFTI(u"testtype"))
         fti_mock.lookupSchema = Mock(return_value=ISchema)
         self.mock_utility(fti_mock, IDexterityFTI, name=u"testtype")
+        alsoProvides(fti_mock, IDexterityFTI)
 
         SCHEMA_CACHE.invalidate("testtype")
 
@@ -433,6 +441,7 @@ class TestContent(MockTestCase):
         fti_mock = Mock(wraps=DexterityFTI(u"testtype"))
         fti_mock.lookupSchema = Mock(return_value=ISchema)
         self.mock_utility(fti_mock, IDexterityFTI, name=u"testtype")
+        alsoProvides(fti_mock, IDexterityFTI)
 
         SCHEMA_CACHE.invalidate("testtype")
 
@@ -462,6 +471,7 @@ class TestContent(MockTestCase):
         fti_mock = Mock(wraps=DexterityFTI(u"testtype"))
         fti_mock.lookupSchema = Mock(return_value=ISchema)
         self.mock_utility(fti_mock, IDexterityFTI, name=u"testtype")
+        alsoProvides(fti_mock, IDexterityFTI)
 
         SCHEMA_CACHE.invalidate("testtype")
 
@@ -487,6 +497,7 @@ class TestContent(MockTestCase):
         fti_mock = Mock(wraps=DexterityFTI(u"testtype"))
         fti_mock.lookupSchema = Mock(return_value=ISchema)
         self.mock_utility(fti_mock, IDexterityFTI, name=u"testtype")
+        alsoProvides(fti_mock, IDexterityFTI)
 
         SCHEMA_CACHE.invalidate("testtype")
 

--- a/plone/dexterity/tests/test_schema_cache.py
+++ b/plone/dexterity/tests/test_schema_cache.py
@@ -4,7 +4,8 @@ from plone.dexterity.fti import DexterityFTI
 from plone.dexterity.interfaces import IDexterityFTI
 from plone.dexterity.schema import SCHEMA_CACHE
 from zope.interface import Interface
-
+from zope.globalrequest import setRequest
+from zope.publisher.browser import TestRequest
 
 try:
     from unittest.mock import Mock
@@ -19,6 +20,7 @@ except ImportError:
 
 class TestSchemaCache(MockTestCase):
     def setUp(self):
+        setRequest(TestRequest())
         SCHEMA_CACHE.clear()
 
     def test_repeated_get_lookup(self):

--- a/plone/dexterity/tests/test_security.py
+++ b/plone/dexterity/tests/test_security.py
@@ -10,6 +10,8 @@ from zope.interface import Interface
 from zope.interface import provider
 from zope.security.interfaces import IPermission
 from zope.security.permission import Permission
+from zope.globalrequest import setRequest
+from zope.publisher.browser import TestRequest
 
 import zope.schema
 
@@ -22,6 +24,7 @@ except ImportError:
 
 class TestAttributeProtection(MockTestCase):
     def setUp(self):
+        setRequest(TestRequest())
         SCHEMA_CACHE.clear()
 
     def test_item(self):


### PR DESCRIPTION
inspired by #108 this fixes the lineage recursion error mentioned here https://github.com/collective/collective.lineage/issues/62 when looking up IDexterityFTI for the new DX-Plone-Siteroot ... though this needs some more investigation, why the FTI lookup doesn't work.