### PR TITLE
fix: avoid setting a default value on methods

### DIFF
--- a/news/158.bugfix
+++ b/news/158.bugfix
@@ -1,0 +1,5 @@
+Avoid setting a default value on methods.
+If a Schema Interface has a method in it, i.e. to be used as a
+constraint for another field, etc. the `default_from_schema` function
+would trip over it while trying to get a default value for it.
+[gforcada, jensens]

--- a/plone/dexterity/content.py
+++ b/plone/dexterity/content.py
@@ -46,6 +46,7 @@ from zope.interface.declarations import getObjectSpecification
 from zope.interface.declarations import implementedBy
 from zope.interface.declarations import Implements
 from zope.interface.declarations import ObjectSpecificationDescriptor
+from zope.interface.interface import Method
 from zope.schema.interfaces import IContextAwareDefaultFactory
 from zope.security.interfaces import IPermission
 
@@ -82,7 +83,7 @@ def _default_from_schema(context, schema, fieldname):
     if schema is None:
         return _marker
     field = schema.get(fieldname, None)
-    if field is None:
+    if field is None or isinstance(field, Method):
         return _marker
     default_factory = getattr(field, "defaultFactory", None)
     if (


### PR DESCRIPTION
If a Schema Interface has a method in it, i.e. to be used as a
constraint for another field, etc. the  function
would trip over it while trying to get a default value for it.

picked from https://github.com/plone/plone.dexterity/commit/80735b5563bed96f67557b328eb31db6acf6c283