### PR TITLE
Fixes schema name generated in Python 2

### DIFF
--- a/news/159.bugfix
+++ b/news/159.bugfix
@@ -1,0 +1,1 @@
+Fixes schema name generated in Python 2. [wesleybl]


### PR DESCRIPTION
As of `plone.dexterity` 2.9.10, `_p_mtime` is used in the schema name. To transform the `_p_mtime` into a string, the `str` function was used. However, in Python 2, the `str` function rounds floats when it's applied to large floats:

Python 2:
```
>>> str(1637689348.9999528)
'1637689349.0'
```

Python 3:
```
>>> str(1637689348.9999528)
'1637689348.9999528'
```
This was causing the schema names in Python 2 to take an unexpected format, causing errors.
So, we need to use the `repr` function, which doesn't round floats.

I was even thinking that `_p_mtime` had a higher precision in Python 3. Then I went to see that it was the str that was rounding the value in Python 2.

This issue was causing random errors in `plone.restapi` tests. Look: plone/plone.restapi#1018

So this fixes plone/plone.restapi#1018