### PR TITLE
Plone 6: Always use lines property for behaviors, no longer ulines

### DIFF
--- a/news/3305.bugfix
+++ b/news/3305.bugfix
@@ -1,0 +1,3 @@
+Plone 6: Always use a lines property for behaviors, no longer the deprecated ulines.
+Part of `issue 3305 <https://github.com/plone/Products.CMFPlone/issues/3305>`_.
+[maurits]

--- a/plone/dexterity/fti.py
+++ b/plone/dexterity/fti.py
@@ -63,10 +63,6 @@ class DexterityFTI(base.DynamicViewTypeInformation):
 
     meta_type = "Dexterity FTI"
 
-    behaviors_type = "ulines"
-    if six.PY2:
-        behaviors_type = "lines"
-
     _properties = base.DynamicViewTypeInformation._properties + (
         {
             "id": "add_permission",
@@ -86,7 +82,7 @@ class DexterityFTI(base.DynamicViewTypeInformation):
         },
         {
             "id": "behaviors",
-            "type": behaviors_type,
+            "type": "ulines",
             "mode": "w",
             "label": "Behaviors",
             "description": "Names of enabled behaviors type",


### PR DESCRIPTION
`ulines` is deprecated, and on Plone 6 it is the same as `lines`.
Part of https://github.com/plone/Products.CMFPlone/issues/3305.
We have an upgrade step in `plone.app.upgrade` which replaces existing `ulines` properties, so we should avoid adding new ones.

Note: I have switched coredev 5.2 to use `plone.dexterity` branch 2.x.

@jensens I am happy to revert this PR to draft status if you want to continue your cleanup PR #160 first.