### PR TITLE
Really always use a lines property for behaviors

### DIFF
--- a/news/3305.bugfix
+++ b/news/3305.bugfix
@@ -1,0 +1,4 @@
+Really always use a lines property for behaviors, no longer the deprecated ulines.
+This improves the fix from the previous release.
+Part of `issue 3305 <https://github.com/plone/Products.CMFPlone/issues/3305>`_.
+[maurits]

--- a/plone/dexterity/fti.py
+++ b/plone/dexterity/fti.py
@@ -82,7 +82,7 @@ class DexterityFTI(base.DynamicViewTypeInformation):
         },
         {
             "id": "behaviors",
-            "type": "ulines",
+            "type": "lines",
             "mode": "w",
             "label": "Behaviors",
             "description": "Names of enabled behaviors type",


### PR DESCRIPTION
In merged and released PR #161 I wrote that we would use a `lines` property, but I fixed it wrong and made it a `ulines` property. This new PR fixes my mistake.
Part of https://github.com/plone/Products.CMFPlone/issues/3305.