### PR TITLE
Optimization: Don't reindex containers when their contents are modified

### DIFF
--- a/plone/dexterity/content.py
+++ b/plone/dexterity/content.py
@@ -38,6 +38,7 @@ from zExceptions import Unauthorized
 from zope.annotation import IAttributeAnnotatable
 from zope.component import queryUtility
 from zope.container.contained import Contained
+from zope.container.interfaces import IContainerModifiedEvent
 from zope.globalrequest import getRequest
 from zope.interface import implementer
 from zope.interface.declarations import getObjectSpecification
@@ -812,6 +813,10 @@ def reindexOnModify(content, event):
     """When an object is modified, re-index it in the catalog"""
 
     if event.object is not content:
+        return
+
+    # Don't reindex just because the container contents changed.
+    if IContainerModifiedEvent.providedBy(event):
         return
 
     # NOTE: We are not using event.descriptions because the field names may


### PR DESCRIPTION
Dexterity content is currently reindexed whenever there is an object modified event. That includes the ContainerModifiedEvent fired when contents of a container are added/removed. Let's see if we can avoid reindexing in that case...

This is NOT a fully backwards compatible change:
- Some sites may have custom indexes or catalog metadata that calculates a value based on the contents of a container.
- It means a container's modification time will not be updated when a contained item is added or removed. (That may be a good change actually, but it's certainly different.)

So I fully expect this to break some tests and I'm not sure if it is a good idea or not. But I want to at least run the tests and see where we're at.

If it does turn out to be okay, we should get it in soon or else wait for Plone 7.