### PR TITLE
Fix webdav tests to pass with Zope 5.8 and the master branch.

### DIFF
--- a/news/844.tests
+++ b/news/844.tests
@@ -1,0 +1,2 @@
+Fix webdav tests to pass with Zope 5.8 and the master branch.
+[maurits]

--- a/plone/dexterity/tests/test_webdav.py
+++ b/plone/dexterity/tests/test_webdav.py
@@ -593,16 +593,18 @@ class TestFolderDataResource(MockTestCase):
   <d:status>HTTP/1.1 200 OK</d:status>
 </d:propstat>
 <d:responsedescription>
-The operation succeded.
+The operation succeeded.
 </d:responsedescription>
 </d:response>
 </d:multistatus>
 """
         )
-
-        result = response.getBody()
-
-        self.assertEqual(body.strip(), result.strip())
+        body = body.strip()
+        result = response.getBody().strip()
+        # TODO: remove next line when Zope 5.8.1 is released and used in coredev.
+        # Then also remove codespell settings from .meta.toml and pyproject.toml.
+        result = result.replace(b"succeded", b"succeeded")
+        self.assertEqual(body, result)
 
     def test_LOCK(self):
         # Too much WebDAV magic - just test that it delegates correctly


### PR DESCRIPTION
Zope 5.8 and earlier have a typo 'succeded', which on master is fixed to 'succeeded'.