### PR TITLE
 Changes made to file primary.py in order to solve the issue of Type …

### DIFF
--- a/plone/dexterity/primary.py
+++ b/plone/dexterity/primary.py
@@ -20,9 +20,12 @@ class PrimaryFieldInfo:
                     primary = (name, field)
                     break
         if not primary:
-            raise TypeError("Could not adapt", context, IPrimaryFieldInfo)
-        self.fieldname, self.field = primary
+            self.fieldname, self.field = None, None
+        else:
+            self.fieldname, self.field = primary
 
     @property
     def value(self):
+        if self.field is None:
+            return None
         return self.field.get(self.context)


### PR DESCRIPTION
As mentioned by - https://github.com/jensens , there is a type error raised if a type has no primary field. A none value is generally expected though. I have made few changes....
In this modified version of the code, if no primary field adapter is found, the fieldname and field attributes are set to None. The value property checks whether the field attribute is None, and returns None if it is, instead of raising an error.
Issue id - https://github.com/plone/plone.dexterity/issues/59#issue-168895640