### PR TITLE
Changes made to file primary.py to return none 

### DIFF
--- a/news/174.bugfix.rst
+++ b/news/174.bugfix.rst
@@ -1,0 +1,12 @@
+Changelog Entry
+===============
+
+3.0.1 (2023-03-04)
+------------------
+Bug fixes:
+
+- Type error is removed and none is returned.
+  In this modified version of the code, if no primary field adapter is found, the fieldname and field attributes are set to None. The value property checks whether the field attribute is None, and returns None if it is, instead of raising an error.
+  [Coder-aadarsh] (#174)
+
+--

--- a/plone/dexterity/primary.py
+++ b/plone/dexterity/primary.py
@@ -20,9 +20,12 @@ class PrimaryFieldInfo:
                     primary = (name, field)
                     break
         if not primary:
-            raise TypeError("Could not adapt", context, IPrimaryFieldInfo)
-        self.fieldname, self.field = primary
+            self.fieldname, self.field = None, None
+        else:
+            self.fieldname, self.field = primary
 
     @property
     def value(self):
+        if self.field is None:
+            return None
         return self.field.get(self.context)

--- a/plone/dexterity/primary.py
+++ b/plone/dexterity/primary.py
@@ -19,13 +19,9 @@ class PrimaryFieldInfo:
                 if IPrimaryField.providedBy(field):
                     primary = (name, field)
                     break
-        if not primary:
-            self.fieldname, self.field = None, None
-        else:
-            self.fieldname, self.field = primary
+        self.fieldname, self.field = primary or (None, None)
 
     @property
     def value(self):
-        if self.field is None:
-            return None
-        return self.field.get(self.context)
+        return self.field.get(self.context) if self.field else None
+


### PR DESCRIPTION
As mentioned by - https://github.com/jensens , there is a type error raised if a type has no primary field. A none value is generally expected though. I have made few changes....
In this modified version of the code, if no primary field adapter is found, the fieldname and field attributes are set to None. The value property checks whether the field attribute is None, and returns None if it is, instead of raising an error.
Issue id - #59 (comment)