### PR TITLE
change interface declaration type #186

### DIFF
--- a/news/187.bug
+++ b/news/187.bug
@@ -1,0 +1,1 @@
+Fix a memory leak as reported in https://github.com/plone/Products.CMFPlone/issues/3829, changing interface decleration type as suggested by @d-maurer in https://github.com/plone/plone.dexterity/issues/186 [mamico]

--- a/news/187.bug
+++ b/news/187.bug
@@ -1,1 +1,1 @@
-Fix a memory leak as reported in https://github.com/plone/Products.CMFPlone/issues/3829, changing interface decleration type as suggested by @d-maurer in https://github.com/plone/plone.dexterity/issues/186 [mamico]
+Fix a memory leak as reported in https://github.com/plone/Products.CMFPlone/issues/3829, changing interface declaration type as suggested by @d-maurer in https://github.com/plone/plone.dexterity/issues/186 [mamico]

--- a/plone/dexterity/content.py
+++ b/plone/dexterity/content.py
@@ -42,8 +42,8 @@ from zope.globalrequest import getRequest
 from zope.interface import implementer
 from zope.interface.declarations import getObjectSpecification
 from zope.interface.declarations import implementedBy
-from zope.interface.declarations import Provides
 from zope.interface.declarations import ObjectSpecificationDescriptor
+from zope.interface.declarations import Provides
 from zope.interface.interface import Method
 from zope.schema.interfaces import IContextAwareDefaultFactory
 from zope.security.interfaces import IPermission

--- a/plone/dexterity/content.py
+++ b/plone/dexterity/content.py
@@ -42,7 +42,7 @@ from zope.globalrequest import getRequest
 from zope.interface import implementer
 from zope.interface.declarations import getObjectSpecification
 from zope.interface.declarations import implementedBy
-from zope.interface.declarations import Implements
+from zope.interface.declarations import Provides
 from zope.interface.declarations import ObjectSpecificationDescriptor
 from zope.interface.interface import Method
 from zope.schema.interfaces import IContextAwareDefaultFactory
@@ -193,7 +193,7 @@ class FTIAwareSpecification(ObjectSpecificationDescriptor):
             return spec
 
         dynamically_provided.append(spec)
-        all_spec = Implements(*dynamically_provided)
+        all_spec = Provides(*dynamically_provided)
         inst._v__providedBy__ = updated + (all_spec,)
 
         return all_spec

--- a/plone/dexterity/content.py
+++ b/plone/dexterity/content.py
@@ -193,7 +193,7 @@ class FTIAwareSpecification(ObjectSpecificationDescriptor):
             return spec
 
         dynamically_provided.append(spec)
-        all_spec = Provides(*dynamically_provided)
+        all_spec = Provides(cls, *dynamically_provided)
         inst._v__providedBy__ = updated + (all_spec,)
 
         return all_spec


### PR DESCRIPTION
Fix a memory leak as reported in https://github.com/plone/Products.CMFPlone/issues/3829, changing interface declaration type as suggested by @d-maurer in https://github.com/plone/plone.dexterity/issues/186