### PR TITLE
#187 backport to 2.x

### DIFF
--- a/news/189.bugfix
+++ b/news/189.bugfix
@@ -1,0 +1,1 @@
+Fix a memory leak as reported in https://github.com/plone/Products.CMFPlone/issues/3829, changing interface declaration type as suggested by @d-maurer in https://github.com/plone/plone.dexterity/issues/186 [mamico]

--- a/plone/dexterity/content.py
+++ b/plone/dexterity/content.py
@@ -44,8 +44,8 @@ from zope.globalrequest import getRequest
 from zope.interface import implementer
 from zope.interface.declarations import getObjectSpecification
 from zope.interface.declarations import implementedBy
-from zope.interface.declarations import Implements
 from zope.interface.declarations import ObjectSpecificationDescriptor
+from zope.interface.declarations import Provides
 from zope.interface.interface import Method
 from zope.schema.interfaces import IContextAwareDefaultFactory
 from zope.security.interfaces import IPermission
@@ -196,7 +196,7 @@ class FTIAwareSpecification(ObjectSpecificationDescriptor):
             return spec
 
         dynamically_provided.append(spec)
-        all_spec = Implements(*dynamically_provided)
+        all_spec = Provides(cls, *dynamically_provided)
         inst._v__providedBy__ = updated + (all_spec,)
 
         return all_spec


### PR DESCRIPTION
As also reported in https://github.com/plone/Products.CMFPlone/issues/3829#issuecomment-1733142496 it might be useful to have fix #187 also for 2.x versions for Plone 5.2 users